### PR TITLE
chore: security/quality cleanup and region-metadata performance work

### DIFF
--- a/.env.migration.example
+++ b/.env.migration.example
@@ -24,6 +24,13 @@ TARGET_S3_FORCE_PATH_STYLE=false
 
 # Keep this low because each worker buffers one legacy image in memory.
 MIGRATION_IMAGE_CONCURRENCY=3
+# Empty legacy Image rows without a MinIO object are always skipped. Set this
+# to true to also skip non-empty imageData rows whose object is missing.
+MIGRATION_SKIP_MISSING_IMAGES=false
+
+# Optional creator UUID for legacy rows whose userUUID is EVENT or PLOT and
+# which have no owner with a valid Minecraft UUID.
+# MIGRATION_SYSTEM_CREATOR_UUID=00000000-0000-0000-0000-000000000000
 
 # Optional overrides if the legacy table names differ.
 # LEGACY_REGIONS_TABLE=Region

--- a/README.md
+++ b/README.md
@@ -62,16 +62,21 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 For Mapbox-based map styles, set your public access token:
 
 ```bash
-NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=your_mapbox_access_token
+MAPBOX_ACCESS_TOKEN=your_mapbox_access_token
 ```
 
 The embedded street-level viewer uses the official Google Maps JavaScript API
 and Apple MapKit JS 5:
 
 ```bash
-NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_browser_api_key
+GOOGLE_MAPS_BROWSER_API_KEY=your_browser_api_key
 APPLE_MAPS_TOKEN=your_mapkit_js_token
 ```
+
+These variables are read at container runtime through `/api/config`, so one
+Docker image can be deployed to multiple environments. The legacy
+`NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` and `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` names
+remain supported, but they no longer need to exist during `next build`.
 
 Enable the Maps JavaScript API for the Google key and restrict it to the
 application's HTTP referrers. The Apple Maps token must include the production

--- a/docs/V2_MIGRATION.md
+++ b/docs/V2_MIGRATION.md
@@ -20,6 +20,12 @@ werden geschlossen. Das Bundesland wird, soweit möglich, aus
 `osmDisplayName` abgeleitet. `landuse` bleibt leer und kann anschließend über
 die bestehende Admin-Funktion neu berechnet werden.
 
+Legacy-Regionen mit `userUUID = EVENT` oder `userUUID = PLOT` werden ebenfalls
+unterstützt. Der Marker bestimmt den Regionstyp. Als Creator wird zuerst die
+Minecraft-UUID des verknüpften Besitzers verwendet, danach optional
+`MIGRATION_SYSTEM_CREATOR_UUID`. Falls beides fehlt, nutzt das Skript stabile
+Platzhalter-UUIDs für Event- beziehungsweise Plot-Regionen.
+
 `User`, `LinkCodes` und `InteractiveBuilding` haben im aktuellen Schema kein
 Ziel und werden nicht migriert. Die Benutzerauflösung erfolgt in der aktuellen
 Map über Keycloak und Minecraft-UUIDs.
@@ -67,6 +73,9 @@ hochgeladen. Dadurch kann ein abgebrochener Lauf wiederholt werden.
   erfolgreich hochgeladen und per `HEAD` geprüft wurde.
 - Alte Bild-URLs werden auf ihren Objekt-Key reduziert. Das historische Format
   `<image-id>-<original-name>.webp` wird damit direkt unterstützt.
+- Alte leere `Image`-Zeilen ohne MinIO-Objekt werden übersprungen und separat
+  geloggt. Mit `MIGRATION_SKIP_MISSING_IMAGES=true` können auch kaputte
+  nicht-leere Bildreferenzen übersprungen werden.
 - Der Ziel-Key lautet `regions/<region-id>/<image-id>.<ext>`.
 - Das Skript stoppt die DB-Phase, wenn Regions- oder Minecraft-UUIDs ungültig
   sind. Fehlerhafte Bilder werden vollständig aufgelistet und führen am Ende

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,15 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    rules: {
+      // `any` mostly remains at third-party boundaries (maplibre/mapbox events,
+      // recharts payloads, motion variants). Surface it as a warning so it is
+      // visible on every build for incremental cleanup, instead of blocking the
+      // build — but keep it discouraged. Prefer precise types in new/logic code.
+      "@typescript-eslint/no-explicit-any": "warn",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/migrations/0003_perf_indexes.sql
+++ b/migrations/0003_perf_indexes.sql
@@ -1,0 +1,11 @@
+-- Performance indexes for the region-metadata / profile / realtime hot paths.
+-- NOTE: drizzle-kit also emitted CREATE TABLE/TYPE statements for mc_servers,
+-- player_positions, player_privacy and teleport_requests because the migration
+-- snapshots predating this change did not describe those (out-of-band) tables.
+-- Those tables already exist in the database, so only the index DDL is kept
+-- here. IF NOT EXISTS keeps the migration safe to (re)apply.
+CREATE INDEX IF NOT EXISTS "player_positions_server_last_seen_idx" ON "player_positions" USING btree ("server_key","last_seen_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "player_positions_last_seen_idx" ON "player_positions" USING btree ("last_seen_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "teleport_requests_status_idx" ON "teleport_requests" USING btree ("status");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "regions_creator_uuid_idx" ON "regions" USING btree ("creatorUUID");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "region_images_region_id_idx" ON "region_images" USING btree ("region_id");

--- a/migrations/meta/0003_snapshot.json
+++ b/migrations/meta/0003_snapshot.json
@@ -1,0 +1,571 @@
+{
+  "id": "9e95df67-82af-481a-8e3e-04ad107ba9a4",
+  "prevId": "e90e5d19-86f1-494d-8130-65de6b8bdc88",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.mc_servers": {
+      "name": "mc_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "states": {
+          "name": "states",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_rotated_at": {
+          "name": "token_rotated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mc_servers_key_unique": {
+          "name": "mc_servers_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_positions": {
+      "name": "player_positions",
+      "schema": "",
+      "columns": {
+        "minecraft_uuid": {
+          "name": "minecraft_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_key": {
+          "name": "server_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "z": {
+          "name": "z",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yaw": {
+          "name": "yaw",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "world": {
+          "name": "world",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'world'"
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_positions_server_last_seen_idx": {
+          "name": "player_positions_server_last_seen_idx",
+          "columns": [
+            {
+              "expression": "server_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "player_positions_last_seen_idx": {
+          "name": "player_positions_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_privacy": {
+      "name": "player_privacy",
+      "schema": "",
+      "columns": {
+        "minecraft_uuid": {
+          "name": "minecraft_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hide_on_map": {
+          "name": "hide_on_map",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "creatorUUID": {
+          "name": "creatorUUID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polygon": {
+          "name": "polygon",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(265)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "area": {
+          "name": "area",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buildings": {
+          "name": "buildings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "landuse": {
+          "name": "landuse",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "modifiedAt": {
+          "name": "modifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "region_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "finished": {
+          "name": "finished",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "builders": {
+          "name": "builders",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "regions_creator_uuid_idx": {
+          "name": "regions_creator_uuid_idx",
+          "columns": [
+            {
+              "expression": "creatorUUID",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.region_images": {
+      "name": "region_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploader_uuid": {
+          "name": "uploader_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "region_images_region_id_idx": {
+          "name": "region_images_region_id_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teleport_requests": {
+      "name": "teleport_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "minecraft_uuid": {
+          "name": "minecraft_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "z": {
+          "name": "z",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "world": {
+          "name": "world",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'world'"
+        },
+        "status": {
+          "name": "status",
+          "type": "teleport_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "delivered_by_server_key": {
+          "name": "delivered_by_server_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "teleport_requests_status_idx": {
+          "name": "teleport_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.region_type": {
+      "name": "region_type",
+      "schema": "public",
+      "values": [
+        "default",
+        "plot",
+        "event"
+      ]
+    },
+    "public.teleport_status": {
+      "name": "teleport_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "delivered",
+        "failed",
+        "expired"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1780338600000,
       "tag": "0002_mc_server_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1782849971276,
+      "tag": "0003_perf_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,30 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "SAMEORIGIN" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  { key: "X-DNS-Prefetch-Control", value: "on" },
+];
+
 const nextConfig: NextConfig = {
   // Enable minimal server output for container images
   output: 'standalone',
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   images: {
     remotePatterns: [new URL("https://minotar.net/**")],
-  }
+  },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/scripts/migrate-v2.mjs
+++ b/scripts/migrate-v2.mjs
@@ -10,6 +10,7 @@ for (const envFile of [".env.migration", ".env"]) {
 
 let GetObjectCommand;
 let HeadObjectCommand;
+let ListObjectsV2Command;
 let PutObjectCommand;
 let S3Client;
 
@@ -18,11 +19,16 @@ async function loadS3Sdk() {
   const sdk = await import("@aws-sdk/client-s3");
   GetObjectCommand = sdk.GetObjectCommand;
   HeadObjectCommand = sdk.HeadObjectCommand;
+  ListObjectsV2Command = sdk.ListObjectsV2Command;
   PutObjectCommand = sdk.PutObjectCommand;
   S3Client = sdk.S3Client;
 }
 
 const MODES = new Set(["all", "db", "images", "verify"]);
+const LEGACY_MARKER_UUIDS = {
+  EVENT: "00000000-0000-0000-0000-000000000001",
+  PLOT: "00000000-0000-0000-0000-000000000002",
+};
 const STATE_NAMES = new Map([
   ["baden-württemberg", "BW"],
   ["baden-wuerttemberg", "BW"],
@@ -179,7 +185,31 @@ function detectState(displayName) {
   return "";
 }
 
+function legacyRegionMarker(value) {
+  const marker = String(value ?? "").trim().toUpperCase();
+  return marker === "EVENT" || marker === "PLOT" ? marker : null;
+}
+
+function resolveCreatorUuid(row) {
+  const direct = normalizeUuid(row.userUUID);
+  if (direct) return direct;
+
+  const owner = normalizeUuid(row.ownerMinecraftUUID);
+  if (owner) return owner;
+
+  const marker = legacyRegionMarker(row.userUUID);
+  if (!marker) return null;
+
+  const configuredFallback = normalizeUuid(
+    process.env.MIGRATION_SYSTEM_CREATOR_UUID,
+  );
+  return configuredFallback ?? LEGACY_MARKER_UUIDS[marker];
+}
+
 function regionType(row) {
+  const marker = legacyRegionMarker(row.userUUID);
+  if (marker === "EVENT") return "event";
+  if (marker === "PLOT") return "plot";
   if (Boolean(row.isEventRegion)) return "event";
   if (Boolean(row.isPlotRegion)) return "plot";
   return "default";
@@ -189,8 +219,7 @@ function makeRegionRecord(row, additionalBuilders) {
   const id = normalizeUuid(row.id);
   if (!id) throw new Error(`Region ${row.id}: id is not a UUID`);
 
-  const creatorUUID =
-    normalizeUuid(row.userUUID) || normalizeUuid(row.ownerMinecraftUUID);
+  const creatorUUID = resolveCreatorUuid(row);
   if (!creatorUUID) {
     throw new Error(`Region ${row.id}: no valid creator Minecraft UUID`);
   }
@@ -286,63 +315,162 @@ async function migrateDatabase(mysqlConnection, pgPool, dryRun) {
   }
   if (dryRun) return { migrated: records.length };
 
-  const client = await pgPool.connect();
-  try {
-    await client.query("BEGIN");
-    for (const record of records) {
-      await client.query(
-        `
-          INSERT INTO regions (
-            id, description, "creatorUUID", polygon, city, state, area,
-            buildings, "createdAt", "modifiedAt", type, address, finished, builders
-          )
-          VALUES (
-            $1, $2, $3, $4::json, $5, $6, $7, $8, $9, $10,
-            $11::region_type, $12, $13, $14::json
-          )
-          ON CONFLICT (id) DO UPDATE SET
-            description = EXCLUDED.description,
-            "creatorUUID" = EXCLUDED."creatorUUID",
-            polygon = EXCLUDED.polygon,
-            city = EXCLUDED.city,
-            state = EXCLUDED.state,
-            area = EXCLUDED.area,
-            buildings = EXCLUDED.buildings,
-            "createdAt" = EXCLUDED."createdAt",
-            "modifiedAt" = EXCLUDED."modifiedAt",
-            type = EXCLUDED.type,
-            address = EXCLUDED.address,
-            finished = EXCLUDED.finished,
-            builders = EXCLUDED.builders
-        `,
-        [
-          record.id,
-          record.description,
-          record.creatorUUID,
-          JSON.stringify(record.polygon),
-          record.city,
-          record.state,
-          record.area,
-          record.buildings,
-          record.createdAt,
-          record.modifiedAt,
-          record.type,
-          record.address,
-          record.finished,
-          JSON.stringify(record.builders),
-        ],
-      );
-    }
-    await client.query("COMMIT");
-  } catch (error) {
-    await client.query("ROLLBACK");
-    throw error;
-  } finally {
-    client.release();
+  const batchSize = numberEnv("MIGRATION_DB_BATCH_SIZE", 200);
+  const totalBatches = Math.ceil(records.length / batchSize);
+  for (let offset = 0; offset < records.length; offset += batchSize) {
+    const batch = records.slice(offset, offset + batchSize);
+    await insertRegionBatchWithRetry(pgPool, batch);
+    const batchIndex = Math.floor(offset / batchSize) + 1;
+    console.log(
+      `[db] committed batch ${batchIndex}/${totalBatches} (${Math.min(offset + batch.length, records.length)}/${records.length})`,
+    );
   }
 
   console.log(`[db] migrated ${records.length} regions`);
   return { migrated: records.length };
+}
+
+async function insertRegionBatchWithRetry(pgPool, batch) {
+  const maxAttempts = numberEnv("MIGRATION_DB_BATCH_RETRIES", 30);
+  const maxBackoffMs = numberEnv("MIGRATION_DB_BACKOFF_CAP_MS", 30_000);
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let client;
+    let succeeded = false;
+    try {
+      client = await pgPool.connect();
+      await client.query("BEGIN");
+      for (const record of batch) {
+        await client.query(
+          `
+            INSERT INTO regions (
+              id, description, "creatorUUID", polygon, city, state, area,
+              buildings, "createdAt", "modifiedAt", type, address, finished, builders
+            )
+            VALUES (
+              $1, $2, $3, $4::json, $5, $6, $7, $8, $9, $10,
+              $11::region_type, $12, $13, $14::json
+            )
+            ON CONFLICT (id) DO UPDATE SET
+              description = EXCLUDED.description,
+              "creatorUUID" = EXCLUDED."creatorUUID",
+              polygon = EXCLUDED.polygon,
+              city = EXCLUDED.city,
+              state = EXCLUDED.state,
+              area = EXCLUDED.area,
+              buildings = EXCLUDED.buildings,
+              "createdAt" = EXCLUDED."createdAt",
+              "modifiedAt" = EXCLUDED."modifiedAt",
+              type = EXCLUDED.type,
+              address = EXCLUDED.address,
+              finished = EXCLUDED.finished,
+              builders = EXCLUDED.builders
+          `,
+          [
+            record.id,
+            record.description,
+            record.creatorUUID,
+            JSON.stringify(record.polygon),
+            record.city,
+            record.state,
+            record.area,
+            record.buildings,
+            record.createdAt,
+            record.modifiedAt,
+            record.type,
+            record.address,
+            record.finished,
+            JSON.stringify(record.builders),
+          ],
+        );
+      }
+      await client.query("COMMIT");
+      succeeded = true;
+      return;
+    } catch (error) {
+      lastError = error;
+      if (client) {
+        try { await client.query("ROLLBACK"); } catch {}
+      }
+      if (!isTransientPgError(error) || attempt === maxAttempts) throw error;
+      const backoffMs = Math.min(1000 * 2 ** Math.min(attempt - 1, 10), maxBackoffMs);
+      console.warn(
+        `[db] batch failed (attempt ${attempt}/${maxAttempts}): ${error?.message ?? error}. Retrying in ${backoffMs}ms — if kubectl port-forward died, restart it now.`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+    } finally {
+      if (client) {
+        try { client.release(!succeeded); } catch {}
+      }
+    }
+  }
+  throw lastError;
+}
+
+async function pgQueryWithRetry(pgPool, sql, params) {
+  const maxAttempts = numberEnv("MIGRATION_DB_QUERY_RETRIES", 30);
+  const maxBackoffMs = numberEnv("MIGRATION_DB_BACKOFF_CAP_MS", 30_000);
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await pgPool.query(sql, params);
+    } catch (error) {
+      lastError = error;
+      if (!isTransientPgError(error) || attempt === maxAttempts) throw error;
+      const backoffMs = Math.min(500 * 2 ** Math.min(attempt - 1, 10), maxBackoffMs);
+      console.warn(
+        `[db] query failed (attempt ${attempt}/${maxAttempts}): ${error?.message ?? error}. Retrying in ${backoffMs}ms — if kubectl port-forward died, restart it now.`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+    }
+  }
+  throw lastError;
+}
+
+function isTransientPgError(error) {
+  const codes = collectErrorCodes(error);
+  const message = String(error?.message ?? "").toLowerCase();
+  const transportCodes = new Set([
+    "ECONNRESET",
+    "ECONNREFUSED",
+    "EPIPE",
+    "ETIMEDOUT",
+    "ENETUNREACH",
+    "EHOSTUNREACH",
+    "EAI_AGAIN",
+  ]);
+  const pgFatalCodes = new Set([
+    "57P01", "57P02", "57P03",
+    "08000", "08001", "08003", "08004", "08006",
+  ]);
+  for (const code of codes) {
+    if (transportCodes.has(code) || pgFatalCodes.has(code)) return true;
+  }
+  return (
+    message.includes("connection terminated") ||
+    message.includes("connection reset") ||
+    message.includes("connection refused") ||
+    message.includes("read econnreset") ||
+    message.includes("server closed the connection") ||
+    message.includes("connection ended") ||
+    message.includes("econnrefused") ||
+    message.includes("etimedout")
+  );
+}
+
+function collectErrorCodes(error) {
+  const codes = new Set();
+  if (!error) return codes;
+  if (error.code) codes.add(error.code);
+  if (Array.isArray(error.errors)) {
+    for (const inner of error.errors) {
+      if (inner?.code) codes.add(inner.code);
+    }
+  }
+  if (error.cause) {
+    for (const code of collectErrorCodes(error.cause)) codes.add(code);
+  }
+  return codes;
 }
 
 function legacyObjectKey(imageData, sourceBucket) {
@@ -358,6 +486,31 @@ function legacyObjectKey(imageData, sourceBucket) {
   } catch {
     return raw.replace(/^\/+/, "").replace(new RegExp(`^${escapeRegex(sourceBucket)}/`), "");
   }
+}
+
+function summarizeAwsError(error) {
+  const metadata = error?.$metadata ?? {};
+  const details = [
+    error?.name,
+    error?.Code,
+    error?.code,
+    error?.message,
+    metadata.httpStatusCode ? `http=${metadata.httpStatusCode}` : null,
+    metadata.requestId ? `requestId=${metadata.requestId}` : null,
+    metadata.extendedRequestId
+      ? `extendedRequestId=${metadata.extendedRequestId}`
+      : null,
+  ].filter(Boolean);
+  return details.length > 0 ? details.join(" ") : String(error);
+}
+
+function withS3Context(operation, bucket, key, error) {
+  const suffix = key ? ` key="${key}"` : "";
+  const wrapped = new Error(
+    `${operation} failed bucket="${bucket}"${suffix}: ${summarizeAwsError(error)}`,
+  );
+  wrapped.cause = error;
+  return wrapped;
 }
 
 function escapeRegex(value) {
@@ -397,8 +550,53 @@ async function objectExists(client, bucket, key) {
   } catch (error) {
     const status = error?.$metadata?.httpStatusCode;
     if (status === 404 || error?.name === "NotFound") return null;
-    throw error;
+    throw withS3Context("HeadObject", bucket, key, error);
   }
+}
+
+async function findLegacyObjectByPrefix(client, bucket, imageId) {
+  const prefix = `${imageId}-`;
+  let response;
+  try {
+    response = await client.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        MaxKeys: 2,
+      }),
+    );
+  } catch (error) {
+    throw withS3Context("ListObjectsV2", bucket, prefix, error);
+  }
+
+  const matches = response.Contents ?? [];
+  if (matches.length === 0) return null;
+  if (matches.length > 1) {
+    throw new Error(
+      `Image ${imageId}: multiple source objects found for prefix "${prefix}"`,
+    );
+  }
+  return matches[0].Key ?? null;
+}
+
+async function resolveLegacySourceObject(client, bucket, imageId, imageData) {
+  const directKey = legacyObjectKey(imageData, bucket);
+  if (directKey) {
+    const head = await objectExists(client, bucket, directKey);
+    if (head) return { key: directKey, head };
+  }
+
+  const prefixKey = await findLegacyObjectByPrefix(client, bucket, imageId);
+  if (!prefixKey) return { key: directKey, head: null };
+
+  const head = await objectExists(client, bucket, prefixKey);
+  if (!head) {
+    throw new Error(
+      `Image ${imageId}: prefix match "${prefixKey}" vanished before HEAD`,
+    );
+  }
+
+  return { key: prefixKey, head };
 }
 
 async function loadLegacyImages(connection) {
@@ -428,8 +626,10 @@ async function migrateImages(mysqlConnection, pgPool, dryRun) {
   const targetBucket = requiredEnv("TARGET_S3_BUCKET");
   const images = await loadLegacyImages(mysqlConnection);
   const concurrency = numberEnv("MIGRATION_IMAGE_CONCURRENCY", 3);
+  const skipMissingImages = booleanEnv("MIGRATION_SKIP_MISSING_IMAGES", false);
   let migrated = 0;
   let skipped = 0;
+  let skippedMissing = 0;
   const failures = [];
 
   console.log(`[images] source: ${images.length} image rows`);
@@ -437,18 +637,32 @@ async function migrateImages(mysqlConnection, pgPool, dryRun) {
   async function migrateOne(row) {
     const id = normalizeUuid(row.id);
     const regionId = normalizeUuid(row.regionId);
-    const uploaderUUID =
-      normalizeUuid(row.userUUID) || normalizeUuid(row.ownerMinecraftUUID);
-    const sourceKey = legacyObjectKey(row.imageData, sourceBucket);
-    if (!id || !regionId || !uploaderUUID || !sourceKey) {
+    const uploaderUUID = resolveCreatorUuid(row);
+    if (!id || !regionId || !uploaderUUID) {
       throw new Error(
         `Image ${row.id}: invalid id, region, uploader, or imageData`,
       );
     }
 
-    const sourceHead = await objectExists(source, sourceBucket, sourceKey);
+    const { key: sourceKey, head: sourceHead } = await resolveLegacySourceObject(
+      source,
+      sourceBucket,
+      String(row.id),
+      row.imageData,
+    );
     if (!sourceHead) {
-      throw new Error(`Image ${row.id}: source object "${sourceKey}" not found`);
+      const hasLegacyReference = String(row.imageData ?? "").trim().length > 0;
+      if (!hasLegacyReference || skipMissingImages) {
+        skippedMissing += 1;
+        console.warn(
+          `[images] skipped missing image=${row.id} region=${row.regionId} imageData="${row.imageData ?? ""}"`,
+        );
+        return;
+      }
+
+      throw new Error(
+        `Image ${row.id}: source object not found for imageData="${row.imageData ?? ""}"`,
+      );
     }
 
     const mimeType = mimeFor(sourceKey, sourceHead.ContentType);
@@ -467,23 +681,35 @@ async function migrateImages(mysqlConnection, pgPool, dryRun) {
 
     let targetHead = await objectExists(target, targetBucket, targetKey);
     if (!targetHead || Number(targetHead.ContentLength) !== sizeBytes) {
-      const response = await source.send(
-        new GetObjectCommand({ Bucket: sourceBucket, Key: sourceKey }),
-      );
+      let response;
+      try {
+        response = await source.send(
+          new GetObjectCommand({ Bucket: sourceBucket, Key: sourceKey }),
+        );
+      } catch (error) {
+        throw withS3Context("GetObject", sourceBucket, sourceKey, error);
+      }
+      if (!response.Body?.transformToByteArray) {
+        throw new Error(`Image ${row.id}: source object body is not readable`);
+      }
       const bytes = await response.Body.transformToByteArray();
-      await target.send(
-        new PutObjectCommand({
-          Bucket: targetBucket,
-          Key: targetKey,
-          Body: bytes,
-          ContentLength: bytes.byteLength,
-          ContentType: mimeType,
-          Metadata: {
-            "legacy-image-id": String(row.id),
-            "legacy-sha256": createHash("sha256").update(bytes).digest("hex"),
-          },
-        }),
-      );
+      try {
+        await target.send(
+          new PutObjectCommand({
+            Bucket: targetBucket,
+            Key: targetKey,
+            Body: bytes,
+            ContentLength: bytes.byteLength,
+            ContentType: mimeType,
+            Metadata: {
+              "legacy-image-id": String(row.id),
+              "legacy-sha256": createHash("sha256").update(bytes).digest("hex"),
+            },
+          }),
+        );
+      } catch (error) {
+        throw withS3Context("PutObject", targetBucket, targetKey, error);
+      }
       targetHead = await objectExists(target, targetBucket, targetKey);
       if (!targetHead || Number(targetHead.ContentLength) !== bytes.byteLength) {
         throw new Error(`Image ${row.id}: target object verification failed`);
@@ -492,7 +718,8 @@ async function migrateImages(mysqlConnection, pgPool, dryRun) {
       skipped += 1;
     }
 
-    await pgPool.query(
+    await pgQueryWithRetry(
+      pgPool,
       `
         INSERT INTO region_images (
           id, region_id, uploader_uuid, s3_key, mime_type,
@@ -528,20 +755,23 @@ async function migrateImages(mysqlConnection, pgPool, dryRun) {
       try {
         await migrateOne(row);
       } catch (error) {
-        failures.push(error.message);
-        console.error(`[images] failed: ${error.message}`);
+        const message = error?.message ?? String(error);
+        failures.push(message);
+        console.error(
+          `[images] failed image=${row.id} region=${row.regionId}: ${message}`,
+        );
       }
     }
   }
 
   await Promise.all(Array.from({ length: concurrency }, () => worker()));
   console.log(
-    `[images] processed: ${migrated}, existing objects reused: ${skipped}, failed: ${failures.length}`,
+    `[images] processed: ${migrated}, existing objects reused: ${skipped}, missing skipped: ${skippedMissing}, failed: ${failures.length}`,
   );
   if (failures.length > 0) {
     throw new Error("Image migration completed with failures");
   }
-  return { migrated, skipped };
+  return { migrated, skipped, skippedMissing };
 }
 
 async function verifyMigration(mysqlConnection, pgPool, verifyObjects) {
@@ -551,7 +781,7 @@ async function verifyMigration(mysqlConnection, pgPool, verifyObjects) {
     `SELECT COUNT(*) AS count FROM ${regionsTable}`,
   );
   const [[sourceImageCount]] = await mysqlConnection.query(
-    `SELECT COUNT(*) AS count FROM ${imagesTable}`,
+    `SELECT COUNT(*) AS count FROM ${imagesTable} WHERE COALESCE(imageData, '') <> ''`,
   );
   const targetRegions = await pgPool.query(
     `SELECT COUNT(*)::int AS count FROM regions`,
@@ -572,7 +802,7 @@ async function verifyMigration(mysqlConnection, pgPool, verifyObjects) {
     `SELECT id FROM ${regionsTable}`,
   );
   const [sourceImageRows] = await mysqlConnection.query(
-    `SELECT id FROM ${imagesTable}`,
+    `SELECT id FROM ${imagesTable} WHERE COALESCE(imageData, '') <> ''`,
   );
   const sourceRegionIds = sourceRegionRows.map((row) => normalizeUuid(row.id));
   const sourceImageIds = sourceImageRows.map((row) => normalizeUuid(row.id));
@@ -580,23 +810,35 @@ async function verifyMigration(mysqlConnection, pgPool, verifyObjects) {
     throw new Error("Legacy database contains invalid region or image UUIDs");
   }
 
+  // Compare against the DISTINCT source ids: `id = ANY(...)` matches each target
+  // row at most once, so duplicate legacy UUIDs would otherwise produce false
+  // "missing" failures.
+  const distinctSourceRegionIds = [...new Set(sourceRegionIds)];
+  const distinctSourceImageIds = [...new Set(sourceImageIds)];
+
   const migratedRegions = await pgPool.query(
     `SELECT id::text FROM regions WHERE id = ANY($1::uuid[])`,
-    [sourceRegionIds],
+    [distinctSourceRegionIds],
   );
   const migratedImages = await pgPool.query(
     `SELECT id::text FROM region_images WHERE id = ANY($1::uuid[])`,
-    [sourceImageIds],
+    [distinctSourceImageIds],
   );
-  if (migratedRegions.rowCount !== sourceRegionIds.length) {
+  if (migratedRegions.rowCount !== distinctSourceRegionIds.length) {
     throw new Error(
-      `Missing migrated regions: expected ${sourceRegionIds.length}, found ${migratedRegions.rowCount}`,
+      `Missing migrated regions: expected ${distinctSourceRegionIds.length}, found ${migratedRegions.rowCount}`,
     );
   }
-  if (migratedImages.rowCount !== sourceImageIds.length) {
-    throw new Error(
-      `Missing migrated images: expected ${sourceImageIds.length}, found ${migratedImages.rowCount}`,
-    );
+  // Images may be intentionally skipped (MIGRATION_SKIP_MISSING_IMAGES); only
+  // treat a shortfall as fatal when skipping is disabled.
+  const missingImages = distinctSourceImageIds.length - migratedImages.rowCount;
+  if (missingImages !== 0) {
+    const detail = `expected ${distinctSourceImageIds.length}, found ${migratedImages.rowCount} (${missingImages} not migrated)`;
+    if (booleanEnv("MIGRATION_SKIP_MISSING_IMAGES", false)) {
+      console.warn(`[verify] image count mismatch: ${detail} — allowed because MIGRATION_SKIP_MISSING_IMAGES is set`);
+    } else {
+      throw new Error(`Missing migrated images: ${detail}`);
+    }
   }
 
   if (!verifyObjects) return counts;
@@ -647,10 +889,33 @@ async function main(argv = process.argv.slice(2)) {
   ]);
   const { Pool } = pg;
   const mysqlConnection = await mysql.createConnection(legacyDatabaseUrl);
+  const poolSize = numberEnv("MIGRATION_PG_POOL_SIZE", 3);
   const pgPool = new Pool({
     connectionString: targetDatabaseUrl,
     ssl: pgSslConfig(),
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 10_000,
+    application_name: "migrate-v2",
+    statement_timeout: numberEnv("MIGRATION_STATEMENT_TIMEOUT_MS", 120_000),
+    max: poolSize,
+    min: poolSize,
+    idleTimeoutMillis: 0,
+    allowExitOnIdle: true,
   });
+  pgPool.on("error", (error) => {
+    console.error(`[pg-pool] idle client error: ${error?.message ?? error}`);
+  });
+  pgPool.on("connect", (client) => {
+    client.query(
+      "SET tcp_keepalives_idle = 30; SET tcp_keepalives_interval = 10; SET tcp_keepalives_count = 6;",
+    ).catch(() => {});
+  });
+
+  const heartbeatMs = numberEnv("MIGRATION_HEARTBEAT_MS", 20_000);
+  const heartbeat = setInterval(() => {
+    pgPool.query("SELECT 1").catch(() => {});
+  }, heartbeatMs);
+  heartbeat.unref();
 
   console.log(
     `[migration] mode=${options.mode} dryRun=${options.dryRun ? "yes" : "no"}`,
@@ -666,6 +931,7 @@ async function main(argv = process.argv.slice(2)) {
       await verifyMigration(mysqlConnection, pgPool, true);
     }
   } finally {
+    clearInterval(heartbeat);
     await Promise.allSettled([mysqlConnection.end(), pgPool.end()]);
   }
 }
@@ -689,4 +955,6 @@ export {
   normalizeUuid,
   parseArgs,
   parsePolygon,
+  resolveCreatorUuid,
+  summarizeAwsError,
 };

--- a/scripts/migrate-v2.test.mjs
+++ b/scripts/migrate-v2.test.mjs
@@ -7,6 +7,8 @@ import {
   normalizeUuid,
   parseArgs,
   parsePolygon,
+  resolveCreatorUuid,
+  summarizeAwsError,
 } from "./migrate-v2.mjs";
 
 test("normalizeUuid accepts dashed and compact UUIDs", () => {
@@ -52,6 +54,21 @@ test("legacyObjectKey supports path-style MinIO URLs", () => {
   );
 });
 
+test("summarizeAwsError keeps useful S3 diagnostics", () => {
+  assert.equal(
+    summarizeAwsError({
+      name: "UnknownError",
+      message: "socket hang up",
+      $metadata: {
+        httpStatusCode: 403,
+        requestId: "request-1",
+        extendedRequestId: "extended-1",
+      },
+    }),
+    "UnknownError socket hang up http=403 requestId=request-1 extendedRequestId=extended-1",
+  );
+});
+
 test("makeRegionRecord maps legacy fields and builders", () => {
   const regionId = "123e4567-e89b-12d3-a456-426614174000";
   const creator = "123e4567-e89b-12d3-a456-426614174001";
@@ -91,6 +108,76 @@ test("makeRegionRecord maps legacy fields and builders", () => {
   assert.deepEqual(result.builders, [builder]);
   assert.equal(result.finished, true);
   assert.deepEqual(result.polygon.at(-1), result.polygon[0]);
+});
+
+test("legacy EVENT and PLOT markers produce typed regions with valid creators", () => {
+  const previous = process.env.MIGRATION_SYSTEM_CREATOR_UUID;
+  delete process.env.MIGRATION_SYSTEM_CREATOR_UUID;
+  const baseRow = {
+    id: "123e4567-e89b-12d3-a456-426614174010",
+    ownerMinecraftUUID: null,
+    description: "",
+    data: "[[52,13],[52.1,13],[52.1,13.1]]",
+    city: "Berlin",
+    osmDisplayName: "Berlin, Deutschland",
+    area: 100,
+    buildings: 0,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    lastModified: new Date("2024-01-01T00:00:00Z"),
+    isEventRegion: 0,
+    isPlotRegion: 0,
+    isFinished: 0,
+  };
+
+  try {
+    const event = makeRegionRecord(
+      { ...baseRow, userUUID: "EVENT" },
+      new Map(),
+    );
+    const plot = makeRegionRecord(
+      {
+        ...baseRow,
+        id: "123e4567-e89b-12d3-a456-426614174011",
+        userUUID: "plot",
+      },
+      new Map(),
+    );
+
+    assert.equal(event.type, "event");
+    assert.equal(event.creatorUUID, "00000000-0000-0000-0000-000000000001");
+    assert.equal(plot.type, "plot");
+    assert.equal(plot.creatorUUID, "00000000-0000-0000-0000-000000000002");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.MIGRATION_SYSTEM_CREATOR_UUID;
+    } else {
+      process.env.MIGRATION_SYSTEM_CREATOR_UUID = previous;
+    }
+  }
+});
+
+test("legacy markers prefer owner and configured creator UUIDs", () => {
+  const owner = "123e4567-e89b-12d3-a456-426614174020";
+  assert.equal(
+    resolveCreatorUuid({ userUUID: "EVENT", ownerMinecraftUUID: owner }),
+    owner,
+  );
+
+  const previous = process.env.MIGRATION_SYSTEM_CREATOR_UUID;
+  process.env.MIGRATION_SYSTEM_CREATOR_UUID =
+    "123e4567-e89b-12d3-a456-426614174021";
+  try {
+    assert.equal(
+      resolveCreatorUuid({ userUUID: "PLOT", ownerMinecraftUUID: null }),
+      "123e4567-e89b-12d3-a456-426614174021",
+    );
+  } finally {
+    if (previous === undefined) {
+      delete process.env.MIGRATION_SYSTEM_CREATOR_UUID;
+    } else {
+      process.env.MIGRATION_SYSTEM_CREATOR_UUID = previous;
+    }
+  }
 });
 
 test("parseArgs supports modes and dry-run", () => {

--- a/src/actions/minecraft/user.ts
+++ b/src/actions/minecraft/user.ts
@@ -1,5 +1,3 @@
-import axios from "axios";
-
 export interface Player {
     meta:         Meta;
     username:     string;
@@ -8,7 +6,7 @@ export interface Player {
     avatar:       string;
     skin_texture: string;
     properties:   Property[];
-    name_history: any[];
+    name_history: unknown[];
 }
 
 export interface Meta {
@@ -21,9 +19,33 @@ export interface Property {
     signature: string;
 }
 
+const UUID_RE =
+    /^[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}$/;
+
 export default async function getUser(uuid: string): Promise<Player | null> {
-    const {data} = await axios.get(`https://playerdb.co/api/player/minecraft/${uuid}`)
-    if(data.code === "player.found")
-        return data.data.player
-    else return null
+    // Validate before interpolating into the upstream URL (prevents path
+    // injection / SSRF via a crafted "uuid").
+    if (!uuid || !UUID_RE.test(uuid)) return null;
+
+    try {
+        // Minecraft profiles change rarely, so cache for 24h in the Next Data
+        // Cache (server) — this collapses the per-builder N+1 to ~1 upstream
+        // request per UUID per day instead of K+1 on every region page view.
+        // NOTE: deliberately no AbortSignal here — passing a signal makes Next
+        // treat the fetch as uncacheable. Responsiveness is bounded with a race
+        // that degrades to null instead, so a hung upstream can't stall a render.
+        const res = await Promise.race([
+            fetch(
+                `https://playerdb.co/api/player/minecraft/${encodeURIComponent(uuid)}`,
+                { next: { revalidate: 86400 } },
+            ),
+            new Promise<null>((resolve) => setTimeout(() => resolve(null), 5000)),
+        ]);
+        if (!res || !res.ok) return null;
+        const data = await res.json();
+        if (data?.code === "player.found") return data.data.player as Player;
+        return null;
+    } catch {
+        return null;
+    }
 }

--- a/src/actions/privacy/Privacy.ts
+++ b/src/actions/privacy/Privacy.ts
@@ -3,22 +3,15 @@
 import { eq } from "drizzle-orm";
 import db from "@/db/drizzle";
 import { playerPrivacy } from "@/db/schema";
-import { getSession } from "@/lib/auth";
+import { requireLinkedUuid } from "@/lib/guards";
 
 export interface PrivacyState {
     hideOnMap: boolean;
 }
 
-async function currentUUID(): Promise<string> {
-    const session = await getSession();
-    const uuid = (session?.user as any)?.minecraft_uuid as string | undefined;
-    if (!uuid) throw new Error("Not authenticated or no Minecraft account linked");
-    return uuid;
-}
-
 export async function getPrivacy(): Promise<PrivacyState> {
-    const uuid = await currentUUID();
-    const row = await db!
+    const uuid = await requireLinkedUuid();
+    const row = await db
         .select()
         .from(playerPrivacy)
         .where(eq(playerPrivacy.minecraftUUID, uuid))
@@ -28,8 +21,8 @@ export async function getPrivacy(): Promise<PrivacyState> {
 }
 
 export async function setHideOnMap(hide: boolean): Promise<PrivacyState> {
-    const uuid = await currentUUID();
-    await db!
+    const uuid = await requireLinkedUuid();
+    await db
         .insert(playerPrivacy)
         .values({ minecraftUUID: uuid, hideOnMap: hide })
         .onConflictDoUpdate({

--- a/src/actions/region/AdminUpdateRegion.ts
+++ b/src/actions/region/AdminUpdateRegion.ts
@@ -1,10 +1,12 @@
 "use server";
 
-import { getSession } from "@/lib/auth";
-import { hasPermission, PERMISSIONS } from "@/lib/permissions";
 import { region } from "@/db/schema";
 import db from "@/db/drizzle";
 import { eq } from "drizzle-orm";
+import { assertUuid, requirePermission } from "@/lib/guards";
+import { PERMISSIONS } from "@/lib/permissions";
+
+const MAX_BUILDERS = 50;
 
 export interface AdminUpdateRegionInput {
     regionId: string;
@@ -21,27 +23,28 @@ export interface AdminUpdateRegionInput {
 }
 
 export async function adminUpdateRegion(input: AdminUpdateRegionInput) {
-    const session = await getSession();
-    if (!session?.user) throw new Error("Not authenticated");
+    await requirePermission(PERMISSIONS.REGIONS_EDIT);
 
-    const roles = session.user.realm_access?.roles ?? [];
-    if (!hasPermission(roles, PERMISSIONS.REGIONS_EDIT)) {
-        throw new Error("Not authorized");
+    const regionId = assertUuid(input.regionId, "Region-ID");
+    const creatorUUID = assertUuid(input.creatorUUID, "Creator-UUID");
+    if (input.builders.length > MAX_BUILDERS) {
+        throw new Error(`Maximal ${MAX_BUILDERS} Builder pro Region.`);
     }
+    const builders = Array.from(
+        new Set(input.builders.map((b) => assertUuid(b, "Builder-UUID"))),
+    );
 
-    const { regionId, ...fields } = input;
-
-    await db?.update(region).set({
-        description: fields.description,
-        finished: fields.finished,
-        type: fields.type,
-        city: fields.city,
-        state: fields.state,
-        address: fields.address,
-        buildings: fields.buildings,
-        area: fields.area,
-        creatorUUID: fields.creatorUUID,
-        builders: fields.builders,
+    await db.update(region).set({
+        description: input.description,
+        finished: input.finished,
+        type: input.type,
+        city: input.city,
+        state: input.state,
+        address: input.address,
+        buildings: input.buildings,
+        area: input.area,
+        creatorUUID,
+        builders,
     }).where(eq(region.id, regionId));
 
     return { success: true };

--- a/src/actions/region/DeleteRegion.ts
+++ b/src/actions/region/DeleteRegion.ts
@@ -3,41 +3,28 @@
 import { eq } from "drizzle-orm";
 import db from "@/db/drizzle";
 import { region, regionImage } from "@/db/schema";
-import { getSession } from "@/lib/auth";
-import { hasPermission, PERMISSIONS } from "@/lib/permissions";
+import { requireRegionAccess } from "@/lib/guards";
+import { PERMISSIONS } from "@/lib/permissions";
 import { deleteObject } from "@/lib/s3";
 
 /**
  * Delete a region. Allowed for the region's creator and for users with the
- * REGIONS_EDIT permission. Associated images (DB rows + S3 objects) are
- * removed too; S3 failures are logged but don't abort the delete.
+ * REGIONS_EDIT permission. The DB rows (region + its image rows) are removed
+ * atomically; the S3 objects are deleted afterwards on a best-effort basis so
+ * a storage hiccup never leaves the database inconsistent.
  */
 export async function deleteRegion(regionId: string): Promise<{ success: true }> {
-    const session = await getSession();
-    if (!session?.user) throw new Error("Nicht angemeldet");
+    await requireRegionAccess(regionId, PERMISSIONS.REGIONS_EDIT);
 
-    const roles = (session.user as any)?.realm_access?.roles ?? [];
-    const isAdmin = hasPermission(roles, PERMISSIONS.REGIONS_EDIT);
-    const userUuid = (session.user as any)?.minecraft_uuid as string | undefined;
-
-    const existing = await db!
-        .select({ creatorUUID: region.creatorUUID })
-        .from(region)
-        .where(eq(region.id, regionId))
-        .limit(1)
-        .then((r) => r[0]);
-    if (!existing) throw new Error("Region nicht gefunden");
-
-    const isCreator = !!userUuid && existing.creatorUUID === userUuid;
-    if (!isCreator && !isAdmin) throw new Error("Keine Berechtigung");
-
-    const images = await db!
+    const images = await db
         .select({ id: regionImage.id, s3Key: regionImage.s3Key })
         .from(regionImage)
         .where(eq(regionImage.regionId, regionId));
 
-    await db!.delete(regionImage).where(eq(regionImage.regionId, regionId));
-    await db!.delete(region).where(eq(region.id, regionId));
+    await db.transaction(async (tx) => {
+        await tx.delete(regionImage).where(eq(regionImage.regionId, regionId));
+        await tx.delete(region).where(eq(region.id, regionId));
+    });
 
     await Promise.allSettled(
         images.map((img) =>

--- a/src/actions/region/GetRegions.ts
+++ b/src/actions/region/GetRegions.ts
@@ -2,33 +2,68 @@
 
 import { region } from "@/db/schema";
 import db from "@/db/drizzle";
-import { and, count, desc, eq, isNotNull, isNull, sum } from "drizzle-orm";
-import type { FeatureCollection, Polygon } from "geojson";
-
-type RegionGeoJSON = FeatureCollection<Polygon, { id: string; finished: boolean }>;
+import { and, count, desc, eq, isNotNull, isNull, sql, sum } from "drizzle-orm";
+import { regionsToCreatorGeoJSON, type RegionGeoJSON } from "@/lib/regionGeo";
 
 export async function getAllRegions() {
     return db?.select().from(region);
 }
 
-export async function getAllRegionsAsGeoJSON() {
-    const regions = await getAllRegions();
-    return {
-        "type": "FeatureCollection",
-        "features": regions?.map((region) => {
-            return {
-                "type": "Feature",
-                "properties": {
-                    "id": region.id,
-                    "type": region.type,
-                    "finished": region.finished,
-                },
-                "geometry": {
-                    "type": "Polygon",
-                    "coordinates": [region.polygon.map(e => [e[1], e[0]]) as [number, number][]]
-                }
-            }
+export interface RegionSearchItem {
+    id: string;
+    city: string;
+    state: string;
+    address: string;
+    description: string | null;
+    type: string;
+    finished: boolean;
+}
+
+/**
+ * Public, minimal projection for the client-side search box. Deliberately
+ * excludes creator/builder Minecraft UUIDs, polygons and other internal fields
+ * so the public map never ships every player's UUID to anonymous visitors.
+ */
+export async function getRegionsForSearch(): Promise<RegionSearchItem[]> {
+    return db
+        ?.select({
+            id: region.id,
+            city: region.city,
+            state: region.state,
+            address: region.address,
+            description: region.description,
+            type: region.type,
+            finished: region.finished,
         })
+        .from(region) ?? [];
+}
+
+export async function getAllRegionsAsGeoJSON() {
+    // Project only the columns the FeatureCollection needs — avoids shipping
+    // landuse JSON, builder/creator UUIDs and other columns for every region on
+    // every public map load.
+    const regions = await db
+        ?.select({
+            id: region.id,
+            type: region.type,
+            finished: region.finished,
+            polygon: region.polygon,
+        })
+        .from(region) ?? [];
+    return {
+        type: "FeatureCollection",
+        features: regions.map((r) => ({
+            type: "Feature",
+            properties: {
+                id: r.id,
+                type: r.type,
+                finished: r.finished,
+            },
+            geometry: {
+                type: "Polygon",
+                coordinates: [r.polygon.map(e => [e[1], e[0]]) as [number, number][]]
+            }
+        }))
     }
 }
 
@@ -47,7 +82,6 @@ export async function getRegionTotalSizeByCreator(creatorUUID: string, filterFin
 
     return query.then(res => {
         const area = res[0].area;
-        console.log(res);
         return area ? parseFloat(area.toString()) : 0;
     });
 }
@@ -76,16 +110,37 @@ export async function getRegionsByCreator(creatorUUID: string) {
 
 export async function getRegionsByCreatorAsGeoJSON(creatorUUID: string): Promise<RegionGeoJSON> {
     const regions = await getRegionsByCreator(creatorUUID);
+    return regionsToCreatorGeoJSON(regions ?? []);
+}
+
+export interface CreatorScalarStats {
+    totalRegions: number;
+    finishedRegions: number;
+    totalFinishedArea: number;
+    totalBuildings: number;
+}
+
+/**
+ * All four headline numbers for a creator's profile in ONE round-trip via
+ * conditional aggregation, replacing four separate per-creator scans.
+ */
+export async function getCreatorScalarStats(creatorUUID: string): Promise<CreatorScalarStats> {
+    const row = await db
+        ?.select({
+            total: sql<number>`count(*)::int`,
+            finished: sql<number>`count(*) filter (where ${region.finished})::int`,
+            finishedArea: sql<string>`coalesce(sum(${region.area}) filter (where ${region.finished}), 0)`,
+            totalBuildings: sql<number>`coalesce(sum(${region.buildings}), 0)::int`,
+        })
+        .from(region)
+        .where(eq(region.creatorUUID, creatorUUID))
+        .then((r) => r?.[0]);
+
     return {
-        type: "FeatureCollection",
-        features: regions?.map((r) => ({
-            type: "Feature",
-            properties: { id: r.id, finished: r.finished },
-            geometry: {
-                type: "Polygon",
-                coordinates: [r.polygon.map(e => [e[1], e[0]]) as [number, number][]]
-            }
-        })) ?? []
+        totalRegions: row?.total ?? 0,
+        finishedRegions: row?.finished ?? 0,
+        totalFinishedArea: row ? parseFloat(String(row.finishedArea ?? "0")) || 0 : 0,
+        totalBuildings: row?.totalBuildings ?? 0,
     };
 }
 

--- a/src/actions/region/RegionImages.ts
+++ b/src/actions/region/RegionImages.ts
@@ -1,10 +1,10 @@
 "use server";
 
 import { randomUUID } from "crypto";
-import { and, asc, eq } from "drizzle-orm";
+import { asc, count, eq } from "drizzle-orm";
 import db from "@/db/drizzle";
 import { region, regionImage } from "@/db/schema";
-import { getSession } from "@/lib/auth";
+import { assertUuid, requireRegionAccess, requireSession } from "@/lib/guards";
 import { hasPermission, PERMISSIONS } from "@/lib/permissions";
 import {
     ALLOWED_IMAGE_MIME_TYPES,
@@ -40,31 +40,17 @@ function toDTO(row: typeof regionImage.$inferSelect): RegionImageDTO {
     };
 }
 
-async function assertCanManageRegion(regionId: string) {
-    const session = await getSession();
-    if (!session?.user) throw new Error("Not authenticated");
-
-    const roles = (session.user as any)?.realm_access?.roles ?? [];
-    const isAdmin = hasPermission(roles, PERMISSIONS.REGIONS_EDIT);
-    const userUuid = (session.user as any)?.minecraft_uuid as string | undefined;
-
-    const existing = await db
-        ?.select({ creatorUUID: region.creatorUUID })
-        .from(region)
-        .where(eq(region.id, regionId))
-        .limit(1)
-        .then((r) => r[0]);
-    if (!existing) throw new Error("Region not found");
-
-    const isCreator = !!userUuid && existing.creatorUUID === userUuid;
-    if (!isCreator && !isAdmin) throw new Error("Not authorized");
-
-    return { userUuid: userUuid ?? "", isAdmin, isCreator };
+async function countRegionImages(regionId: string): Promise<number> {
+    return db
+        .select({ value: count() })
+        .from(regionImage)
+        .where(eq(regionImage.regionId, regionId))
+        .then((r) => r[0]?.value ?? 0);
 }
 
 export async function listRegionImages(regionId: string): Promise<RegionImageDTO[]> {
     if (!regionId) return [];
-    const rows = await db!
+    const rows = await db
         .select()
         .from(regionImage)
         .where(eq(regionImage.regionId, regionId))
@@ -88,7 +74,7 @@ export async function createRegionImageUpload(input: {
         throw new Error("S3 ist auf dem Server nicht konfiguriert.");
     }
 
-    await assertCanManageRegion(input.regionId);
+    await requireRegionAccess(input.regionId, PERMISSIONS.REGIONS_EDIT);
 
     if (!ALLOWED_IMAGE_MIME_TYPES.includes(input.mimeType as AllowedImageMime)) {
         throw new Error(
@@ -104,12 +90,7 @@ export async function createRegionImageUpload(input: {
         );
     }
 
-    const existingCount = await db!
-        .select({ count: regionImage.id })
-        .from(regionImage)
-        .where(eq(regionImage.regionId, input.regionId))
-        .then((r) => r.length);
-    if (existingCount >= MAX_IMAGES_PER_REGION) {
+    if (await countRegionImages(input.regionId) >= MAX_IMAGES_PER_REGION) {
         throw new Error(
             `Maximal ${MAX_IMAGES_PER_REGION} Bilder pro Region. Bitte vorher alte Bilder löschen.`
         );
@@ -132,7 +113,10 @@ export async function finalizeRegionImageUpload(input: {
     key: string;
     originalName?: string;
 }): Promise<RegionImageDTO> {
-    const { userUuid } = await assertCanManageRegion(input.regionId);
+    const { userUuid } = await requireRegionAccess(input.regionId, PERMISSIONS.REGIONS_EDIT);
+    if (!userUuid) {
+        throw new Error("Zum Hochladen muss ein Minecraft-Account verknüpft sein.");
+    }
 
     // Schlüssel muss im Region-Namespace liegen (defensive Check).
     const expectedPrefix = `regions/${input.regionId}/`;
@@ -156,7 +140,14 @@ export async function finalizeRegionImageUpload(input: {
         throw new Error("Hochgeladene Datei hat einen ungültigen Typ.");
     }
 
-    const inserted = await db!
+    // Re-check the per-region cap now that the object exists, deleting the
+    // orphaned upload if a concurrent finalize already filled the quota.
+    if (await countRegionImages(input.regionId) >= MAX_IMAGES_PER_REGION) {
+        await deleteObject(input.key).catch(() => {});
+        throw new Error(`Maximal ${MAX_IMAGES_PER_REGION} Bilder pro Region.`);
+    }
+
+    const inserted = await db
         .insert(regionImage)
         .values({
             regionId: input.regionId,
@@ -172,13 +163,11 @@ export async function finalizeRegionImageUpload(input: {
 }
 
 export async function deleteRegionImage(imageId: string): Promise<{ success: true }> {
-    const session = await getSession();
-    if (!session?.user) throw new Error("Not authenticated");
-    const roles = (session.user as any)?.realm_access?.roles ?? [];
+    assertUuid(imageId, "Bild-ID");
+    const { roles, userUuid } = await requireSession();
     const isAdmin = hasPermission(roles, PERMISSIONS.REGIONS_EDIT);
-    const userUuid = (session.user as any)?.minecraft_uuid as string | undefined;
 
-    const row = await db!
+    const row = await db
         .select()
         .from(regionImage)
         .where(eq(regionImage.id, imageId))
@@ -186,7 +175,7 @@ export async function deleteRegionImage(imageId: string): Promise<{ success: tru
         .then((r) => r[0]);
     if (!row) throw new Error("Bild nicht gefunden");
 
-    const creatorUUID = await db!
+    const creatorUUID = await db
         .select({ creatorUUID: region.creatorUUID })
         .from(region)
         .where(eq(region.id, row.regionId))
@@ -195,9 +184,9 @@ export async function deleteRegionImage(imageId: string): Promise<{ success: tru
 
     const isCreator = !!userUuid && creatorUUID === userUuid;
     const isUploader = !!userUuid && row.uploaderUUID === userUuid;
-    if (!isCreator && !isAdmin && !isUploader) throw new Error("Not authorized");
+    if (!isCreator && !isAdmin && !isUploader) throw new Error("Keine Berechtigung");
 
-    await db!.delete(regionImage).where(eq(regionImage.id, imageId));
+    await db.delete(regionImage).where(eq(regionImage.id, imageId));
     await deleteObject(row.s3Key).catch((err) =>
         console.error(`[regionImages] S3 delete failed for ${row.s3Key}:`, err?.message ?? err)
     );

--- a/src/actions/region/TransferRegions.ts
+++ b/src/actions/region/TransferRegions.ts
@@ -1,10 +1,10 @@
 "use server";
 
-import { getSession } from "@/lib/auth";
-import { hasPermission, PERMISSIONS } from "@/lib/permissions";
 import { region as regionTable } from "@/db/schema";
 import db from "@/db/drizzle";
 import { eq } from "drizzle-orm";
+import { assertUuid, requirePermission } from "@/lib/guards";
+import { PERMISSIONS } from "@/lib/permissions";
 
 // Placeholder UUID for plot/event regions that lose their creator attribution
 const SYSTEM_UUID = "00000000-0000-0000-0000-000000000000";
@@ -16,22 +16,17 @@ export interface TransferPreview {
     total: number;
 }
 
-async function requireAdmin() {
-    const session = await getSession();
-    if (!session?.user) throw new Error("Not authenticated");
-    const roles = session.user.realm_access?.roles ?? [];
-    if (!hasPermission(roles, PERMISSIONS.REGIONS_EDIT)) throw new Error("Not authorized");
-}
-
 export async function previewTransfer(sourceUUID: string, targetUUID: string): Promise<TransferPreview> {
-    await requireAdmin();
+    await requirePermission(PERMISSIONS.REGIONS_EDIT);
+    assertUuid(sourceUUID, "Quell-UUID");
+    assertUuid(targetUUID, "Ziel-UUID");
 
-    const regions = await db?.select({
+    const regions = await db.select({
         id: regionTable.id,
         type: regionTable.type,
         creatorUUID: regionTable.creatorUUID,
         builders: regionTable.builders,
-    }).from(regionTable) ?? [];
+    }).from(regionTable);
 
     let defaultAsCreator = 0;
     let plotEventAsCreator = 0;
@@ -55,37 +50,43 @@ export async function previewTransfer(sourceUUID: string, targetUUID: string): P
 }
 
 export async function executeTransfer(sourceUUID: string, targetUUID: string): Promise<{ transferred: number }> {
-    await requireAdmin();
+    await requirePermission(PERMISSIONS.REGIONS_EDIT);
+    assertUuid(sourceUUID, "Quell-UUID");
+    assertUuid(targetUUID, "Ziel-UUID");
 
-    const regions = await db?.select().from(regionTable) ?? [];
-    let transferred = 0;
+    // Run the whole reassignment atomically so a mid-loop failure can't leave
+    // attribution half-transferred.
+    return db.transaction(async (tx) => {
+        const regions = await tx.select().from(regionTable);
+        let transferred = 0;
 
-    for (const r of regions) {
-        if (r.creatorUUID === sourceUUID) {
-            if (r.type === "default") {
-                // Transfer to target: update creator, clean up builders
-                const newBuilders = (r.builders ?? [])
-                    .filter((u) => u !== sourceUUID && u !== targetUUID);
-                await db?.update(regionTable)
-                    .set({ creatorUUID: targetUUID, builders: newBuilders })
+        for (const r of regions) {
+            if (r.creatorUUID === sourceUUID) {
+                if (r.type === "default") {
+                    // Transfer to target: update creator, clean up builders
+                    const newBuilders = (r.builders ?? [])
+                        .filter((u) => u !== sourceUUID && u !== targetUUID);
+                    await tx.update(regionTable)
+                        .set({ creatorUUID: targetUUID, builders: newBuilders })
+                        .where(eq(regionTable.id, r.id));
+                } else {
+                    // Plot/Event: clear attribution
+                    await tx.update(regionTable)
+                        .set({ creatorUUID: SYSTEM_UUID, builders: [] })
+                        .where(eq(regionTable.id, r.id));
+                }
+                transferred++;
+            } else if ((r.builders ?? []).includes(sourceUUID)) {
+                const newBuilders = r.type === "default"
+                    ? [...(r.builders ?? []).filter((u) => u !== sourceUUID && u !== targetUUID), targetUUID]
+                    : (r.builders ?? []).filter((u) => u !== sourceUUID);
+                await tx.update(regionTable)
+                    .set({ builders: newBuilders })
                     .where(eq(regionTable.id, r.id));
-            } else {
-                // Plot/Event: clear attribution
-                await db?.update(regionTable)
-                    .set({ creatorUUID: SYSTEM_UUID, builders: [] })
-                    .where(eq(regionTable.id, r.id));
+                transferred++;
             }
-            transferred++;
-        } else if ((r.builders ?? []).includes(sourceUUID)) {
-            const newBuilders = r.type === "default"
-                ? [...(r.builders ?? []).filter((u) => u !== sourceUUID && u !== targetUUID), targetUUID]
-                : (r.builders ?? []).filter((u) => u !== sourceUUID);
-            await db?.update(regionTable)
-                .set({ builders: newBuilders })
-                .where(eq(regionTable.id, r.id));
-            transferred++;
         }
-    }
 
-    return { transferred };
+        return { transferred };
+    });
 }

--- a/src/actions/region/UpdateRegion.ts
+++ b/src/actions/region/UpdateRegion.ts
@@ -1,9 +1,12 @@
-"use server"
+"use server";
 
-import { getSession } from "@/lib/auth";
 import { region } from "@/db/schema";
 import db from "@/db/drizzle";
 import { eq } from "drizzle-orm";
+import { assertUuid, requireRegionAccess } from "@/lib/guards";
+import { PERMISSIONS } from "@/lib/permissions";
+
+const MAX_BUILDERS = 50;
 
 export async function updateRegion({
     regionId,
@@ -16,23 +19,19 @@ export async function updateRegion({
     finished: boolean;
     builders: string[];
 }) {
-    const session = await getSession();
-    if (!session?.user?.minecraft_uuid) {
-        throw new Error("Not authenticated");
+    // Creator or any user with REGIONS_EDIT may update the region.
+    await requireRegionAccess(regionId, PERMISSIONS.REGIONS_EDIT);
+
+    if (builders.length > MAX_BUILDERS) {
+        throw new Error(`Maximal ${MAX_BUILDERS} Builder pro Region.`);
     }
+    const normalizedBuilders = Array.from(
+        new Set(builders.map((b) => assertUuid(b, "Builder-UUID"))),
+    );
 
-    const existing = await db
-        ?.select({ creatorUUID: region.creatorUUID })
-        .from(region)
-        .where(eq(region.id, regionId))
-        .limit(1)
-        .then((r) => r[0]);
-
-    if (!existing) throw new Error("Region not found");
-    if (existing.creatorUUID !== session.user.minecraft_uuid) {
-        throw new Error("Not authorized");
-    }
-
-    await db?.update(region).set({ description, finished, builders }).where(eq(region.id, regionId));
+    await db
+        .update(region)
+        .set({ description, finished, builders: normalizedBuilders })
+        .where(eq(region.id, regionId));
     return { success: true };
 }

--- a/src/actions/region/UpdateRegionPolygon.ts
+++ b/src/actions/region/UpdateRegionPolygon.ts
@@ -1,60 +1,72 @@
 "use server";
 
-import { getSession } from "@/lib/auth";
-import { hasPermission, PERMISSIONS } from "@/lib/permissions";
 import { region } from "@/db/schema";
 import db from "@/db/drizzle";
 import { eq } from "drizzle-orm";
 import { fetchLandUseStats } from "@/lib/landuse";
 import { fetchBuildingCount } from "@/lib/buildings";
+import { closePolygon } from "@/lib/geo";
+import { requireRegionAccess } from "@/lib/guards";
+import { PERMISSIONS } from "@/lib/permissions";
 
-function closePolygon(coords: [number, number][]): [number, number][] {
-    if (coords.length < 2) return coords;
-    const first = coords[0];
-    const last = coords[coords.length - 1];
-    if (first[0] === last[0] && first[1] === last[1]) return coords;
-    return [...coords, first];
+const MAX_POLYGON_POINTS = 1000;
+
+/** Rejects polygons with out-of-range or non-finite coordinates. */
+function assertValidPolygon(polygon: [number, number][]): void {
+    if (polygon.length < 3 || polygon.length > MAX_POLYGON_POINTS) {
+        throw new Error("Ungültiges Polygon.");
+    }
+    for (const [lat, lng] of polygon) {
+        if (
+            !Number.isFinite(lat) ||
+            !Number.isFinite(lng) ||
+            lat < -90 || lat > 90 ||
+            lng < -180 || lng > 180
+        ) {
+            throw new Error("Ungültige Koordinaten im Polygon.");
+        }
+    }
 }
 
 export async function updateRegionPolygon(regionId: string, polygon: [number, number][]) {
-    const session = await getSession();
-    if (!session?.user) throw new Error("Not authenticated");
-
-    const roles = (session.user as any)?.realm_access?.roles ?? [];
-    const isAdmin = hasPermission(roles, PERMISSIONS.REGIONS_EDIT);
-
-    const existing = await db
-        ?.select({ creatorUUID: region.creatorUUID })
-        .from(region)
-        .where(eq(region.id, regionId))
-        .limit(1)
-        .then((r) => r[0]);
-
-    if (!existing) throw new Error("Region not found");
-
-    const isCreator = existing.creatorUUID === (session.user as any)?.minecraft_uuid;
-    if (!isCreator && !isAdmin) throw new Error("Not authorized");
+    await requireRegionAccess(regionId, PERMISSIONS.REGIONS_EDIT);
+    assertValidPolygon(polygon);
 
     const closed = closePolygon(polygon);
 
     // Save polygon immediately, clear stale landuse + buildings so the UI shows
     // "wird neu berechnet" while the background jobs run.
     await db
-        ?.update(region)
+        .update(region)
         .set({ polygon: closed, landuse: null, buildings: 0 })
         .where(eq(region.id, regionId));
 
-    // Recalculate landuse + buildings in the background — doesn't block the response
+    // Only apply a background recalculation if the polygon still matches the
+    // one we just stored — otherwise a slower recalculation from an earlier
+    // edit could clobber a newer polygon.
+    const applyIfUnchanged = async (set: Partial<typeof region.$inferInsert>) => {
+        const current = await db
+            .select({ polygon: region.polygon })
+            .from(region)
+            .where(eq(region.id, regionId))
+            .limit(1)
+            .then((r) => r[0]);
+        if (current && JSON.stringify(current.polygon) === JSON.stringify(closed)) {
+            await db.update(region).set(set).where(eq(region.id, regionId));
+        }
+    };
+
+    // Recalculate landuse + buildings in the background — doesn't block the response.
     fetchLandUseStats(closed)
-        .then((landuse) => db?.update(region).set({ landuse }).where(eq(region.id, regionId)))
+        .then((landuse) => applyIfUnchanged({ landuse }))
         .catch((err) =>
-            console.error(`[updateRegionPolygon] landuse refresh failed for ${regionId}:`, err.message)
+            console.error(`[updateRegionPolygon] landuse refresh failed for ${regionId}:`, err.message),
         );
 
     fetchBuildingCount(closed)
-        .then((buildings) => db?.update(region).set({ buildings }).where(eq(region.id, regionId)))
+        .then((buildings) => applyIfUnchanged({ buildings }))
         .catch((err) =>
-            console.error(`[updateRegionPolygon] building refresh failed for ${regionId}:`, err.message)
+            console.error(`[updateRegionPolygon] building refresh failed for ${regionId}:`, err.message),
         );
 
     return { success: true };

--- a/src/actions/servers/McServers.ts
+++ b/src/actions/servers/McServers.ts
@@ -4,8 +4,8 @@ import { randomBytes } from "crypto";
 import { asc, eq } from "drizzle-orm";
 import db from "@/db/drizzle";
 import { mcServer } from "@/db/schema";
-import { getSession } from "@/lib/auth";
-import { hasPermission, PERMISSIONS } from "@/lib/permissions";
+import { requirePermission } from "@/lib/guards";
+import { PERMISSIONS } from "@/lib/permissions";
 import { hashToken } from "@/lib/mcAuth";
 
 export interface McServerSummary {
@@ -19,11 +19,7 @@ export interface McServerSummary {
 }
 
 async function requireAdmin(): Promise<void> {
-    const session = await getSession();
-    const roles = session?.user?.realm_access?.roles ?? [];
-    if (!hasPermission(roles, PERMISSIONS.SERVERS_MANAGE)) {
-        throw new Error("Not authorized");
-    }
+    await requirePermission(PERMISSIONS.SERVERS_MANAGE);
 }
 
 const KEY_PATTERN = /^[a-z0-9][a-z0-9-_]{0,62}[a-z0-9]$/;

--- a/src/actions/stats/GetGlobalStats.ts
+++ b/src/actions/stats/GetGlobalStats.ts
@@ -2,7 +2,6 @@
 
 import db from "@/db/drizzle";
 import { region, type LandUseStats } from "@/db/schema";
-import { count, desc, sum } from "drizzle-orm";
 import { aggregatePlayerScores, type PlayerScore, type ScoringRegion } from "@/lib/scoring";
 
 export interface GlobalStats {
@@ -34,7 +33,25 @@ export interface GlobalStats {
 }
 
 export async function getGlobalStats(): Promise<GlobalStats> {
-    const all = await db!.select().from(region);
+    // Select only the columns the aggregation/scoring actually reads. In
+    // particular this drops the heavy `polygon` JSON (never used here), which is
+    // by far the largest column, from the wire for every region.
+    const all = await db!
+        .select({
+            id: region.id,
+            finished: region.finished,
+            area: region.area,
+            buildings: region.buildings,
+            creatorUUID: region.creatorUUID,
+            builders: region.builders,
+            state: region.state,
+            type: region.type,
+            createdAt: region.createdAt,
+            landuse: region.landuse,
+            address: region.address,
+            city: region.city,
+        })
+        .from(region);
 
     const totals = {
         regions: all.length,

--- a/src/actions/teleport/Teleport.ts
+++ b/src/actions/teleport/Teleport.ts
@@ -1,29 +1,32 @@
 "use server";
 
-import { eq } from "drizzle-orm";
+import { and, eq, gt } from "drizzle-orm";
 import db from "@/db/drizzle";
 import { region, teleportRequest } from "@/db/schema";
-import { getSession } from "@/lib/auth";
-
-function polygonCenterLatLng(polygon: [number, number][]): [number, number] {
-    let lat = 0;
-    let lng = 0;
-    for (const [a, b] of polygon) {
-        lat += a;
-        lng += b;
-    }
-    return [lat / polygon.length, lng / polygon.length];
-}
-
-async function authedUuid(): Promise<string> {
-    const session = await getSession();
-    const uuid = (session?.user as any)?.minecraft_uuid as string | undefined;
-    if (!uuid) throw new Error("Not authenticated or no Minecraft account linked");
-    return uuid;
-}
+import { assertUuid, requireLinkedUuid } from "@/lib/guards";
+import { polygonCenterLatLng } from "@/lib/geo";
 
 export interface TeleportResponse {
     id: string;
+}
+
+/** Reject a new teleport if the user already queued one in the last few seconds. */
+async function assertNoRecentPending(uuid: string): Promise<void> {
+    const since = new Date(Date.now() - 5_000);
+    const recent = await db
+        .select({ id: teleportRequest.id })
+        .from(teleportRequest)
+        .where(
+            and(
+                eq(teleportRequest.minecraftUUID, uuid),
+                eq(teleportRequest.status, "pending"),
+                gt(teleportRequest.createdAt, since),
+            ),
+        )
+        .limit(1);
+    if (recent.length > 0) {
+        throw new Error("Bitte warte einen Moment, bevor du erneut teleportierst.");
+    }
 }
 
 /**
@@ -36,9 +39,11 @@ export interface TeleportResponse {
  * to MC world coordinates via Terra++.
  */
 export async function teleportToRegion(regionId: string): Promise<TeleportResponse> {
-    const uuid = await authedUuid();
+    const uuid = await requireLinkedUuid();
+    assertUuid(regionId, "Region-ID");
+    await assertNoRecentPending(uuid);
 
-    const r = await db!
+    const r = await db
         .select()
         .from(region)
         .where(eq(region.id, regionId))
@@ -48,7 +53,7 @@ export async function teleportToRegion(regionId: string): Promise<TeleportRespon
 
     const [lat, lng] = polygonCenterLatLng(r.polygon as [number, number][]);
 
-    const inserted = await db!
+    const inserted = await db
         .insert(teleportRequest)
         .values({
             minecraftUUID: uuid,
@@ -68,10 +73,16 @@ export async function teleportToRegion(regionId: string): Promise<TeleportRespon
  * coordinate teleport, not a region teleport.
  */
 export async function teleportToCoordinates(lat: number, lng: number): Promise<TeleportResponse> {
-    if (!Number.isFinite(lat) || !Number.isFinite(lng)) throw new Error("Invalid coordinates");
-    const uuid = await authedUuid();
+    if (
+        !Number.isFinite(lat) || !Number.isFinite(lng) ||
+        lat < -90 || lat > 90 || lng < -180 || lng > 180
+    ) {
+        throw new Error("Invalid coordinates");
+    }
+    const uuid = await requireLinkedUuid();
+    await assertNoRecentPending(uuid);
 
-    const inserted = await db!
+    const inserted = await db
         .insert(teleportRequest)
         .values({
             minecraftUUID: uuid,

--- a/src/app/(authenticated)/profile/page.tsx
+++ b/src/app/(authenticated)/profile/page.tsx
@@ -1,12 +1,10 @@
 import {
+    getCreatorScalarStats,
     getMostPopularStateByCreator,
-    getRegionCountByCreator,
-    getRegionTotalSizeByCreator,
-    getRegionsByCreatorAsGeoJSON,
     getRegionStatsByStateByCreator,
-    getTotalBuildingsByCreator,
     getRegionsByCreator,
 } from "@/actions/region/GetRegions";
+import { regionsToCreatorGeoJSON } from "@/lib/regionGeo";
 import { getSession } from "@/lib/auth";
 import { stateCodeToName } from "@/lib/federalStates";
 import { Building2, CheckCircle2, Circle, LandPlot, Map, MapPin } from "lucide-react";
@@ -28,25 +26,19 @@ export default async function ProfilePage() {
     const session = await getSession();
     const uuid = session?.user.minecraft_uuid || "";
 
-    const [
-        totalRegions,
-        finishedRegions,
-        totalFinishedArea,
-        mostPopularState,
-        geoJSON,
-        stateStats,
-        totalBuildings,
-        recentRegions,
-    ] = await Promise.all([
-        getRegionCountByCreator(uuid),
-        getRegionCountByCreator(uuid, true),
-        getRegionTotalSizeByCreator(uuid, true),
+    // Four headline numbers in one query; the creator's rows fetched ONCE and
+    // reused for both the mini-map geojson and the "recent" cards.
+    const [scalarStats, mostPopularState, regions, stateStats] = await Promise.all([
+        getCreatorScalarStats(uuid),
         getMostPopularStateByCreator(uuid, true),
-        getRegionsByCreatorAsGeoJSON(uuid),
+        getRegionsByCreator(uuid),
         getRegionStatsByStateByCreator(uuid),
-        getTotalBuildingsByCreator(uuid),
-        getRegionsByCreator(uuid).then(r => r?.slice(0, 4) ?? []),
     ]);
+
+    const { totalRegions, finishedRegions, totalFinishedArea, totalBuildings } = scalarStats;
+    const allRegions = regions ?? [];
+    const geoJSON = regionsToCreatorGeoJSON(allRegions);
+    const recentRegions = allRegions.slice(0, 4);
 
     const finishedPct = totalRegions > 0 ? Math.round((finishedRegions / totalRegions) * 100) : 0;
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,6 @@
 import { getSession } from "@/lib/auth";
 import { getRegionLanduseStats } from "@/actions/region/GetRegions";
-import { getRegionCountByCreator } from "@/actions/region/GetRegions";
-import { LayoutDashboard, LandPlot, CheckCircle2, AlertCircle } from "lucide-react";
+import { LandPlot, CheckCircle2, AlertCircle } from "lucide-react";
 import Link from "next/link";
 import db from "@/db/drizzle";
 import { region } from "@/db/schema";

--- a/src/app/admin/regions/refresh/page.tsx
+++ b/src/app/admin/regions/refresh/page.tsx
@@ -75,9 +75,10 @@ export default function AdminRegionsPage() {
                     } catch {}
                 }
             }
-        } catch (e: any) {
-            if (e?.name !== "AbortError") {
-                setLog(prev => [{ city: `Verbindungsfehler: ${e?.message ?? String(e)}`, success: false }, ...prev]);
+        } catch (e: unknown) {
+            if (!(e instanceof Error) || e.name !== "AbortError") {
+                const message = e instanceof Error ? e.message : String(e);
+                setLog(prev => [{ city: `Verbindungsfehler: ${message}`, success: false }, ...prev]);
                 setPhase("idle");
             }
         }

--- a/src/app/api/admin/regions/refresh-metadata/route.ts
+++ b/src/app/api/admin/regions/refresh-metadata/route.ts
@@ -1,9 +1,18 @@
+import { z } from "zod";
 import { getSession } from "@/lib/auth";
 import { hasPermission, PERMISSIONS } from "@/lib/permissions";
 import { fetchLandUseStats } from "@/lib/landuse";
+import { getErrorMessage } from "@/lib/errors";
 import db from "@/db/drizzle";
 import { region } from "@/db/schema";
 import { eq, isNull } from "drizzle-orm";
+
+const bodySchema = z.object({ mode: z.enum(["all", "missing"]) });
+
+// Process several regions at once. OVERPASS_API_URL is a private, keyed
+// instance (apikey header), so a small pool is safe — sized to that instance's
+// capacity rather than the public "2 slots" fair-use limit.
+const REFRESH_CONCURRENCY = 4;
 
 type ProgressEvent =
     | { type: "start"; total: number }
@@ -20,7 +29,12 @@ export async function POST(request: Request) {
         return new Response("Forbidden", { status: 403 });
     }
 
-    const { mode } = await request.json() as { mode: "all" | "missing" };
+    let mode: "all" | "missing";
+    try {
+        ({ mode } = bodySchema.parse(await request.json()));
+    } catch {
+        return new Response("Invalid body", { status: 400 });
+    }
 
     const encoder = new TextEncoder();
 
@@ -31,29 +45,43 @@ export async function POST(request: Request) {
                     ? await db?.select({ id: region.id, city: region.city, polygon: region.polygon }).from(region).where(isNull(region.landuse)) ?? []
                     : await db?.select({ id: region.id, city: region.city, polygon: region.polygon }).from(region) ?? [];
 
-                controller.enqueue(encoder.encode(sse({ type: "start", total: rows.length })));
+                const total = rows.length;
+                controller.enqueue(encoder.encode(sse({ type: "start", total })));
 
                 let done = 0;
                 let errors = 0;
+                let next = 0;
 
-                for (const r of rows) {
-                    try {
-                        const landuse = await fetchLandUseStats(r.polygon as [number, number][]);
-                        await db?.update(region).set({ landuse }).where(eq(region.id, r.id));
-                        done++;
-                        controller.enqueue(encoder.encode(sse({ type: "progress", done, total: rows.length, city: r.city, success: true })));
-                    } catch (err) {
-                        done++;
-                        errors++;
-                        const msg = err instanceof Error ? err.message : String(err);
-                        console.error(`[refresh-metadata] failed for region ${r.id} (${r.city}):`, err);
-                        controller.enqueue(encoder.encode(sse({ type: "progress", done, total: rows.length, city: r.city, success: false, error: msg })));
+                // Bounded worker pool: each worker pulls the next region until the
+                // queue is drained. Landuse is computed independently per region,
+                // so concurrency does not change any result; the in-flight Overpass
+                // requests are capped at REFRESH_CONCURRENCY instead of a per-item
+                // sleep. `done`/`errors` mutations are safe (single-threaded JS).
+                const worker = async () => {
+                    while (true) {
+                        const i = next++;
+                        if (i >= rows.length) return;
+                        const r = rows[i];
+                        try {
+                            const landuse = await fetchLandUseStats(r.polygon as [number, number][]);
+                            await db?.update(region).set({ landuse }).where(eq(region.id, r.id));
+                            done++;
+                            controller.enqueue(encoder.encode(sse({ type: "progress", done, total, city: r.city, success: true })));
+                        } catch (err) {
+                            done++;
+                            errors++;
+                            // Log the real cause server-side; send only a generic message to the client.
+                            console.error(`[refresh-metadata] failed for region ${r.id} (${r.city}):`, getErrorMessage(err));
+                            controller.enqueue(encoder.encode(sse({ type: "progress", done, total, city: r.city, success: false, error: "Verarbeitung fehlgeschlagen" })));
+                        }
                     }
-                    // Small delay to avoid hammering Overpass API
-                    await new Promise(res => setTimeout(res, 500));
-                }
+                };
 
-                controller.enqueue(encoder.encode(sse({ type: "done", done, total: rows.length, errors })));
+                await Promise.all(
+                    Array.from({ length: Math.min(REFRESH_CONCURRENCY, rows.length) }, () => worker()),
+                );
+
+                controller.enqueue(encoder.encode(sse({ type: "done", done, total, errors })));
             } finally {
                 controller.close();
             }

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+function readRuntimeEnv(name: string): string | undefined {
+    return process.env[name];
+}
+
+export async function GET() {
+    return NextResponse.json(
+        {
+            mapboxAccessToken:
+                readRuntimeEnv("MAPBOX_ACCESS_TOKEN") ??
+                readRuntimeEnv("NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN") ??
+                "",
+            googleMapsApiKey:
+                readRuntimeEnv("GOOGLE_MAPS_BROWSER_API_KEY") ??
+                readRuntimeEnv("NEXT_PUBLIC_GOOGLE_MAPS_API_KEY") ??
+                "",
+        },
+        {
+            headers: {
+                "Cache-Control": "no-store",
+            },
+        },
+    );
+}

--- a/src/app/api/maps/apple-token/route.ts
+++ b/src/app/api/maps/apple-token/route.ts
@@ -1,6 +1,19 @@
+import { getSession } from "@/lib/auth";
+import { hasPermission, PERMISSIONS } from "@/lib/permissions";
+
 export const dynamic = "force-dynamic";
 
 export async function GET() {
+    // The MapKit JS token is delivered to the browser by design, but the
+    // Look Around feature is gated behind a permission, so gate the token too.
+    const session = await getSession();
+    if (!session?.user || !hasPermission(session.user.realm_access?.roles ?? [], PERMISSIONS.MAP_STREET_LEVEL_VIEW)) {
+        return new Response("Forbidden", {
+            status: 403,
+            headers: { "Cache-Control": "no-store" },
+        });
+    }
+
     const token = process.env.APPLE_MAPS_TOKEN;
 
     if (!token) {

--- a/src/app/api/mc/positions/route.ts
+++ b/src/app/api/mc/positions/route.ts
@@ -41,11 +41,8 @@ export async function POST(req: NextRequest) {
     let parsed: z.infer<typeof Body>;
     try {
         parsed = Body.parse(await req.json());
-    } catch (e: any) {
-        return NextResponse.json(
-            { error: "Invalid body", details: e?.issues ?? e?.message },
-            { status: 400 },
-        );
+    } catch {
+        return NextResponse.json({ error: "Invalid body" }, { status: 400 });
     }
 
     if (parsed.players.length === 0) {
@@ -116,7 +113,9 @@ export async function DELETE(req: NextRequest) {
     if (auth instanceof NextResponse) return auth;
 
     const uuid = req.nextUrl.searchParams.get("uuid");
-    if (!uuid) return NextResponse.json({ error: "uuid required" }, { status: 400 });
+    if (!uuid || !z.string().uuid().safeParse(uuid).success) {
+        return NextResponse.json({ error: "valid uuid required" }, { status: 400 });
+    }
 
     await db!
         .delete(playerPosition)

--- a/src/app/api/mc/teleports/pending/route.ts
+++ b/src/app/api/mc/teleports/pending/route.ts
@@ -86,11 +86,8 @@ export async function POST(req: NextRequest) {
     let parsed: z.infer<typeof AckBody>;
     try {
         parsed = AckBody.parse(await req.json());
-    } catch (e: any) {
-        return NextResponse.json(
-            { error: "Invalid body", details: e?.issues ?? e?.message },
-            { status: 400 },
-        );
+    } catch {
+        return NextResponse.json({ error: "Invalid body" }, { status: 400 });
     }
 
     const now = new Date();

--- a/src/app/api/players/stream/route.ts
+++ b/src/app/api/players/stream/route.ts
@@ -60,14 +60,23 @@ async function snapshot(): Promise<unknown> {
 export async function GET(req: NextRequest) {
     const encoder = new TextEncoder();
 
-    let tickTimer: ReturnType<typeof setInterval> | null = null;
+    let tickTimer: ReturnType<typeof setTimeout> | null = null;
     let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+    let stopped = false;
+
+    const cleanup = () => {
+        stopped = true;
+        if (tickTimer) clearTimeout(tickTimer);
+        if (keepaliveTimer) clearInterval(keepaliveTimer);
+        tickTimer = null;
+        keepaliveTimer = null;
+    };
 
     const stream = new ReadableStream({
         async start(controller) {
             let closed = false;
             const safeEnqueue = (chunk: string) => {
-                if (closed) return;
+                if (closed || stopped) return;
                 try {
                     controller.enqueue(encoder.encode(chunk));
                 } catch {
@@ -76,11 +85,23 @@ export async function GET(req: NextRequest) {
                 }
             };
 
-            const cleanup = () => {
-                if (tickTimer) clearInterval(tickTimer);
-                if (keepaliveTimer) clearInterval(keepaliveTimer);
-                tickTimer = null;
-                keepaliveTimer = null;
+            // Self-scheduling tick: the next snapshot is only scheduled once the
+            // current one settles, so a slow DB can't queue overlapping ticks.
+            const scheduleTick = () => {
+                if (stopped || closed) return;
+                tickTimer = setTimeout(async () => {
+                    try {
+                        const snap = await snapshot();
+                        safeEnqueue(`event: snapshot\ndata: ${JSON.stringify(snap)}\n\n`);
+                    } catch (e) {
+                        // Keep the connection alive on transient errors; log the
+                        // real cause server-side rather than leaking it to clients.
+                        console.error("[players/stream] snapshot failed:", e);
+                        safeEnqueue(`: error\n\n`);
+                    } finally {
+                        scheduleTick();
+                    }
+                }, TICK_MS);
             };
 
             // Suggest reconnect delay to the browser's EventSource.
@@ -90,19 +111,11 @@ export async function GET(req: NextRequest) {
             try {
                 const first = await snapshot();
                 safeEnqueue(`event: snapshot\ndata: ${JSON.stringify(first)}\n\n`);
-            } catch {
-                // ignore — we'll retry on the next tick
+            } catch (e) {
+                console.error("[players/stream] initial snapshot failed:", e);
             }
 
-            tickTimer = setInterval(async () => {
-                try {
-                    const snap = await snapshot();
-                    safeEnqueue(`event: snapshot\ndata: ${JSON.stringify(snap)}\n\n`);
-                } catch (e) {
-                    // Send a comment so the connection stays alive even on transient errors.
-                    safeEnqueue(`: error ${(e as Error)?.message ?? "unknown"}\n\n`);
-                }
-            }, TICK_MS);
+            scheduleTick();
 
             keepaliveTimer = setInterval(() => {
                 safeEnqueue(`: ping\n\n`);
@@ -119,8 +132,7 @@ export async function GET(req: NextRequest) {
             });
         },
         cancel() {
-            if (tickTimer) clearInterval(tickTimer);
-            if (keepaliveTimer) clearInterval(keepaliveTimer);
+            cleanup();
         },
     });
 

--- a/src/app/api/region/route.ts
+++ b/src/app/api/region/route.ts
@@ -2,18 +2,25 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
 import * as turf from "@turf/turf";
-import axios from "axios";
 import { Language, PlaceType2 } from "@googlemaps/google-maps-services-js";
 import db from "@/db/drizzle";
 import { region } from "@/db/schema";
 import { requireMcAuth, type McAuthContext } from "@/lib/mcAuth";
 import { fetchLandUseStats } from "@/lib/landuse";
+import { fetchBuildingCount } from "@/lib/buildings";
+import { closePolygon } from "@/lib/geo";
+import { getErrorMessage } from "@/lib/errors";
 import gMapsClient from "@/lib/googleMaps";
 
 export const runtime = "nodejs";
 
+const latLng = z.tuple([
+    z.number().min(-90).max(90),
+    z.number().min(-180).max(180),
+]);
+
 const bodySchema = z.object({
-    polygon: z.array(z.tuple([z.number(), z.number()])).min(3),
+    polygon: z.array(latLng).min(3).max(1000),
     creatorUUID: z.uuid(),
 });
 
@@ -35,14 +42,6 @@ const STATE_NAME_TO_CODE: Record<string, string> = {
     "Schleswig-Holstein": "SH",
     "Thüringen": "TH",
 };
-
-function closePolygon(coords: [number, number][]): [number, number][] {
-    if (coords.length < 2) return coords;
-    const first = coords[0];
-    const last = coords[coords.length - 1];
-    if (first[0] === last[0] && first[1] === last[1]) return coords;
-    return [...coords, first];
-}
 
 async function authOrThrow(req: NextRequest): Promise<McAuthContext | NextResponse> {
     try {
@@ -86,38 +85,9 @@ async function geocodeCenter(polygonLatLng: [number, number][]): Promise<Geocode
             city,
             state,
         };
-    } catch (err: any) {
-        console.error("[region] reverse geocode failed:", err?.message);
+    } catch (err: unknown) {
+        console.error("[region] reverse geocode failed:", getErrorMessage(err));
         return { address: "", city: "Unbekannt", state: "" };
-    }
-}
-
-async function countBuildings(polygonLatLng: [number, number][]): Promise<number> {
-    const poly = polygonLatLng.map((coord) => coord.join(" ")).join(" ");
-    const query = `[out:json][timeout:25];
-(
-  node["building"]["building"!~"grandstand"]["building"!~"roof"](poly:"${poly}");
-  way["building"]["building"!~"grandstand"]["building"!~"roof"](poly:"${poly}");
-  relation["building"]["building"!~"grandstand"]["building"!~"roof"](poly:"${poly}");
-);
-out count;`;
-
-    try {
-        const res = await axios.post(
-            process.env.OVERPASS_API_URL!,
-            `data=${encodeURIComponent(query)}`,
-            {
-                headers: {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    apikey: process.env.OVERPASS_API_KEY,
-                },
-                timeout: 30_000,
-            },
-        );
-        return parseInt(res.data?.elements?.[0]?.tags?.total) || 0;
-    } catch (err: any) {
-        console.error("[region] building count failed:", err?.message);
-        return 0;
     }
 }
 
@@ -135,24 +105,22 @@ export async function POST(req: NextRequest) {
     let parsed: z.infer<typeof bodySchema>;
     try {
         parsed = bodySchema.parse(await req.json());
-    } catch (e: any) {
-        return NextResponse.json(
-            { error: "Invalid body", details: e?.issues ?? e?.message },
-            { status: 400 },
-        );
+    } catch (e: unknown) {
+        console.error("[region] invalid body:", getErrorMessage(e));
+        return NextResponse.json({ error: "Invalid body" }, { status: 400 });
     }
 
     const polygon = closePolygon(parsed.polygon as [number, number][]);
     const turfPolygon = turf.polygon([polygon.map(([lat, lng]) => [lng, lat])]);
     const area = turf.area(turfPolygon);
 
-    const [meta, buildings] = await Promise.all([
-        geocodeCenter(polygon),
-        countBuildings(polygon),
-    ]);
+    // Only the geocode (fast, ~100-300ms) blocks the plugin's response. Building
+    // count and landuse are slow Overpass calls, so they run fire-and-forget and
+    // backfill the row afterwards (buildings defaults to 0 in the schema).
+    const meta = await geocodeCenter(polygon);
 
     try {
-        const inserted = await db!
+        const inserted = await db
             .insert(region)
             .values({
                 polygon,
@@ -163,16 +131,19 @@ export async function POST(req: NextRequest) {
                 city: meta.city,
                 state: meta.state,
                 area: area.toFixed(2),
-                buildings,
             })
             .returning({ id: region.id });
 
         const regionId = inserted[0].id;
 
-        // Fire-and-forget; never blocks the plugin's response.
+        // Fire-and-forget; never block the plugin's response on Overpass.
+        fetchBuildingCount(polygon)
+            .then((buildings) => db.update(region).set({ buildings }).where(eq(region.id, regionId)))
+            .catch((err) => console.error(`[region] building count failed for ${regionId}:`, getErrorMessage(err)));
+
         fetchLandUseStats(polygon)
-            .then((landuse) => db!.update(region).set({ landuse }).where(eq(region.id, regionId)))
-            .catch((err) => console.error(`[region] landuse fetch failed for ${regionId}:`, err.message));
+            .then((landuse) => db.update(region).set({ landuse }).where(eq(region.id, regionId)))
+            .catch((err) => console.error(`[region] landuse fetch failed for ${regionId}:`, getErrorMessage(err)));
 
         return NextResponse.json({ id: regionId }, { status: 201 });
     } catch (err) {

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -51,11 +51,16 @@ export default function Error({
             <p className="text-muted-foreground">Das Kompetenzteam arbeitet bereits an einer Lösung.</p>
             <pre className="text-xs mt-4 bg-card rounded-lg p-2">{error.message}</pre>
 
-            <Link href="/">
-                <Button variant="secondary" className="mt-6">
-                    Zur Startseite
+            <div className="flex gap-3 mt-6">
+                <Button variant="default" onClick={() => reset()}>
+                    Erneut versuchen
                 </Button>
-            </Link>
+                <Link href="/">
+                    <Button variant="secondary">
+                        Zur Startseite
+                    </Button>
+                </Link>
+            </div>
         </div>
     );
 }

--- a/src/app/region/[id]/opengraph-image.tsx
+++ b/src/app/region/[id]/opengraph-image.tsx
@@ -12,36 +12,37 @@ export const size = {
 
 export const contentType = 'image/png'
 
+const UUID_RE =
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+// Load the font files once per process, not on every OG-image request.
+let fontsPromise: Promise<[Buffer, Buffer, Buffer, Buffer]> | null = null;
+function loadFonts(): Promise<[Buffer, Buffer, Buffer, Buffer]> {
+    if (!fontsPromise) {
+        fontsPromise = Promise.all([
+            readFile(join(process.cwd(), 'assets/outfit-v15-latin-500.ttf')),
+            readFile(join(process.cwd(), 'assets/outfit-v15-latin-600.ttf')),
+            readFile(join(process.cwd(), 'assets/outfit-v15-latin-700.ttf')),
+            readFile(join(process.cwd(), 'assets/outfit-v15-latin-800.ttf')),
+        ]);
+    }
+    return fontsPromise;
+}
+
 // Image generation
 export default async function Image({ params }: { params: { id: string } }) {
 
-    const region = await getRegion(params.id);
-    const poly = region?.polygon.map(e => e.reverse().join(",")).join("|");
+    // Region fetch and font loading are independent — run them concurrently.
+    const [region, [outfit500, outfit600, outfit700, outfit800]] = await Promise.all([
+        UUID_RE.test(params.id) ? getRegion(params.id) : Promise.resolve(null),
+        loadFonts(),
+    ]);
+
+    // Build "lng,lat|lng,lat|..." WITHOUT mutating the stored polygon array.
+    const poly = region?.polygon.map(e => `${e[1]},${e[0]}`).join("|");
     const imageUrl = "https://tiles.dachstein.cloud/styles/btedarklight/static/auto/500x630.png?path=" + poly + "&fill=rgba(0,128,255,0.3)&stroke=rgba(0,128,255,1)&strokeWidth=4&padding=0.1"
 
-
     const creator = await getUser(region?.creatorUUID || "");
-
-    const outfitRegular = await readFile(
-        join(process.cwd(), 'assets/outfit-v15-latin-regular.ttf')
-    )
-
-    const outfit500 = await readFile(
-        join(process.cwd(), 'assets/outfit-v15-latin-500.ttf')
-    )
-
-    const outfit600 = await readFile(
-        join(process.cwd(), 'assets/outfit-v15-latin-600.ttf')
-    )
-
-    const outfit700 = await readFile(
-        join(process.cwd(), 'assets/outfit-v15-latin-700.ttf')
-    )
-
-    const outfit800 = await readFile(
-        join(process.cwd(), 'assets/outfit-v15-latin-800.ttf')
-    )
-
 
     return new ImageResponse(
         (

--- a/src/app/region/[id]/page.tsx
+++ b/src/app/region/[id]/page.tsx
@@ -65,18 +65,20 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
 
 export default async function RegionPage({ params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
-    const region = await getRegion(id);
+    // region + session don't depend on each other — fetch concurrently.
+    const [region, session] = await Promise.all([getRegion(id), getSession()]);
     if (!region) notFound();
 
-    const owner = await getUser(region.creatorUUID);
+    // Creator + all builder profiles resolve concurrently (and getUser is cached).
+    const [owner, builderProfilesRaw] = await Promise.all([
+        getUser(region.creatorUUID),
+        Promise.all((region.builders ?? []).map((uuid) => getUser(uuid))),
+    ]);
+    const builderProfiles = builderProfilesRaw.filter((p): p is NonNullable<typeof p> => p !== null);
 
-    const session = await getSession();
     const isCreator = session?.user?.minecraft_uuid === region.creatorUUID;
-    const roles = (session?.user as any)?.realm_access?.roles ?? [];
+    const roles = session?.user?.realm_access?.roles ?? [];
     const canUpload = isCreator || hasPermission(roles, PERMISSIONS.REGIONS_EDIT);
-    const builderProfiles = await Promise.all(
-        (region.builders ?? []).map((uuid) => getUser(uuid))
-    ).then(profiles => profiles.filter((p): p is Awaited<ReturnType<typeof getUser>> & {} => p !== null));
 
     const area = parseFloat(region.area ?? "0");
     const formattedArea = formatAreaWithMode(area, "full");

--- a/src/components/admin/NavigationBar.tsx
+++ b/src/components/admin/NavigationBar.tsx
@@ -38,8 +38,7 @@ export default function AdminNavigationBar() {
             </div>
 
             <nav className="flex-1 p-3 space-y-0.5">
-                {NAV_ITEMS.map(({ href, label, icon: Icon, exact, children }) => {
-                    const active = isActive(href, exact);
+                {NAV_ITEMS.map(({ href, label, icon: Icon, children }) => {
                     const sectionActive = pathname.startsWith(href);
                     return (
                         <div key={href}>

--- a/src/components/admin/regions/RegionAdminEditDialog.tsx
+++ b/src/components/admin/regions/RegionAdminEditDialog.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { adminUpdateRegion, type AdminUpdateRegionInput } from "@/actions/region/AdminUpdateRegion";
+import { adminUpdateRegion } from "@/actions/region/AdminUpdateRegion";
 import getUser, { type Player } from "@/actions/minecraft/user";
 import { AnimatePresence, motion } from "motion/react";
 
@@ -125,7 +125,7 @@ export default function RegionAdminEditDialog({ region, open, onOpenChange, onSa
                     .map((p) => ({ uuid: p.raw_id, username: p.username, avatar: p.avatar }))
             );
         });
-    }, [open, region]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [open, region]);
 
     const isDirty = region
         ? address !== region.address ||

--- a/src/components/admin/regions/TransferRegionsForm.tsx
+++ b/src/components/admin/regions/TransferRegionsForm.tsx
@@ -1,17 +1,13 @@
 "use client";
 
 import { useState, useRef, useCallback, useTransition } from "react";
-import { SearchIcon, LoaderIcon, ArrowRightIcon, AlertTriangleIcon, CheckIcon, XIcon } from "lucide-react";
+import { SearchIcon, LoaderIcon, ArrowRightIcon, AlertTriangleIcon, CheckIcon } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import getUser, { type Player } from "@/actions/minecraft/user";
 import { previewTransfer, executeTransfer, type TransferPreview } from "@/actions/region/TransferRegions";
 import { AnimatePresence, motion } from "motion/react";
 import { Button } from "@/components/ui/button";
-
-interface PlayerCard {
-    player: Player;
-}
 
 function PlayerSearch({
     label,

--- a/src/components/admin/servers/ServerEditDialog.tsx
+++ b/src/components/admin/servers/ServerEditDialog.tsx
@@ -53,7 +53,8 @@ export default function ServerEditDialog({ open, onOpenChange, server, onSaved, 
     function toggleState(code: string) {
         setStates((prev) => {
             const next = new Set(prev);
-            next.has(code) ? next.delete(code) : next.add(code);
+            if (next.has(code)) next.delete(code);
+            else next.add(code);
             return next;
         });
     }

--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -7,7 +7,6 @@ import { usePathname } from "next/navigation";
 import { cx } from "class-variance-authority";
 import { LockIcon } from "@/components/ui/lock";
 import { HomeIcon } from "@/components/ui/home";
-import { ChartPieIcon } from "@/components/ui/chart-pie";
 import { useState } from "react";
 import { motion } from "motion/react";
 import { ChartColumnIncreasingIcon } from "@/components/ui/chart-column-increasing";
@@ -19,7 +18,7 @@ import useSearchStore from "@/stores/SearchStore";
 
 interface NavigationButtonProps {
     iconOnly?: boolean;
-    icon?: React.JSXElementConstructor<any>;
+    icon?: React.ElementType;
     label?: string;
     pathname?: string;
     onClick?: () => void;
@@ -30,7 +29,7 @@ const NavigationButton = ({ iconOnly, label, icon, onClick, pathname }: Navigati
     const path = usePathname();
 
     if (iconOnly) {
-        let Icon = icon as any;
+        const Icon = icon as React.ElementType;
 
         return (
             <Tooltip>

--- a/src/components/common/QueryWrapper.tsx
+++ b/src/components/common/QueryWrapper.tsx
@@ -1,16 +1,27 @@
 "use client"
 
+import { useState, type ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
-const queryClient = new QueryClient()
+export default function QueryWrapper({ children }: { children: ReactNode }) {
+    // One client per mounted provider — never shared across requests/instances.
+    const [queryClient] = useState(
+        () =>
+            new QueryClient({
+                defaultOptions: {
+                    queries: {
+                        staleTime: 60_000,
+                        refetchOnWindowFocus: false,
+                    },
+                },
+            }),
+    );
 
-
-export default function QueryWrapper(props: any) {
     return (
         <QueryClientProvider client={queryClient}>
-            {props.children}
+            {children}
             <ReactQueryDevtools initialIsOpen={false} client={queryClient} buttonPosition={"top-left"} />
         </QueryClientProvider>
-    )
+    );
 }

--- a/src/components/map/Controls.tsx
+++ b/src/components/map/Controls.tsx
@@ -13,7 +13,6 @@ import useMapStyleStore from "@/stores/MapStyleStore";
 import useMapOverlayStore from "@/stores/MapOverlayStore";
 import { getMapAttributionsById, MAP_STYLES, type MapStyleId } from "@/lib/mapStyles";
 import type { StaticImageData } from "next/image";
-import { Badge } from "../ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { useSession } from "next-auth/react";
 import { hasPermission, PERMISSIONS } from "@/lib/permissions";

--- a/src/components/map/LivePlayersLayer.tsx
+++ b/src/components/map/LivePlayersLayer.tsx
@@ -44,7 +44,15 @@ function PlayerMarker({ uuid, username }: { uuid: string; username: string }) {
                 title={username}
             >
                 {avatar ? (
-                    <img src={avatar} alt={username} className="size-full object-cover" />
+                    <img
+                        src={avatar}
+                        alt={username}
+                        className="size-full object-cover"
+                        onError={(e) => {
+                            const fallback = `https://minotar.net/helm/${uuid}/64`;
+                            if (e.currentTarget.src !== fallback) e.currentTarget.src = fallback;
+                        }}
+                    />
                 ) : (
                     <div className="size-full bg-neutral-800" />
                 )}

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -7,26 +7,27 @@ import { useAllRegionsAsGeoJSON } from "@/dataHooks/regions/useAllRegions";
 import { useEffect, useState } from "react";
 import useRegionPane from "@/stores/RegionPaneStore";
 import useMapStyleStore from "@/stores/MapStyleStore";
-import useRegionShapeEdit from "@/stores/RegionShapeEditStore";
 import RegionShapeEditor from "./RegionShapeEditor";
 import LivePlayersLayer from "./LivePlayersLayer";
 import { getMapStyleById } from "@/lib/mapStyles";
+import { getPublicRuntimeConfig } from "@/lib/publicRuntimeConfig";
 import maplibregl from "maplibre-gl";
 import useStreetLevelStore from "@/stores/StreetLevelStore";
-
-const mapboxAccessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 
 export default function Map() {
 
     const { data: regionGeoJSON, isLoading } = useAllRegionsAsGeoJSON();
     const { mainMap: map } = useMap();
-    const regionPane = useRegionPane();
+    // Select only the (stable) action so this component doesn't re-render — and
+    // the click handler doesn't re-bind — whenever unrelated store fields change.
+    const openRegion = useRegionPane((s) => s.openRegion);
     const styleId = useMapStyleStore((state) => state.styleId);
     const hydrateStyleId = useMapStyleStore((state) => state.hydrateStyleId);
     const mapStyle = getMapStyleById(styleId);
     const isMapboxStyle = typeof mapStyle === "string" && mapStyle.startsWith("mapbox://");
     const [mapLib, setMapLib] = useState<any>(maplibregl);
     const [activeEngine, setActiveEngine] = useState<"maplibre" | "mapbox">("maplibre");
+    const [mapboxAccessToken, setMapboxAccessToken] = useState("");
     const [isStyleReady, setIsStyleReady] = useState<boolean>(false);
     const [viewState, setViewState] = useState({
         longitude: 10.447683,
@@ -51,24 +52,30 @@ export default function Map() {
                 return;
             }
 
-            const mapboxModule = await import("mapbox-gl");
+            const [mapboxModule, runtimeConfig] = await Promise.all([
+                import("mapbox-gl"),
+                getPublicRuntimeConfig(),
+            ]);
+            if (!isMounted) return;
+
             const mapboxgl = mapboxModule.default;
-            if (mapboxAccessToken) {
-                mapboxgl.accessToken = mapboxAccessToken;
+            if (runtimeConfig.mapboxAccessToken) {
+                mapboxgl.accessToken = runtimeConfig.mapboxAccessToken;
             }
 
-            if (isMounted) {
-                setMapLib(mapboxgl);
-                setActiveEngine("mapbox");
-            }
+            setMapboxAccessToken(runtimeConfig.mapboxAccessToken);
+            setMapLib(mapboxgl);
+            setActiveEngine("mapbox");
         };
 
-        resolveMapLib();
+        resolveMapLib().catch((error) => {
+            console.error("Mapbox konnte nicht initialisiert werden:", error);
+        });
 
         return () => {
             isMounted = false;
         };
-    }, [isMapboxStyle, mapboxAccessToken]);
+    }, [isMapboxStyle]);
 
     const isEngineReady = isMapboxStyle ? activeEngine === "mapbox" : activeEngine === "maplibre";
 
@@ -111,7 +118,7 @@ export default function Map() {
                 return;
             }
 
-            regionPane.openRegion(features[0].properties.id);
+            openRegion(features[0].properties.id);
         };
 
         map.on('click', handleMapClick);
@@ -133,7 +140,7 @@ export default function Map() {
             map.off('mouseenter', 'region-layer', handleMouseEnter);
             map.off('mouseleave', 'region-layer', handleMouseLeave);
         };
-    }, [isEngineReady, isSelectingStreetLevel, map, regionPane]);
+    }, [isEngineReady, isSelectingStreetLevel, map, openRegion]);
 
     // Colors matching the WelcomeScreen legend:
     // red   = event

--- a/src/components/map/region/Region3DMap.tsx
+++ b/src/components/map/region/Region3DMap.tsx
@@ -19,14 +19,7 @@ export default function Region3DMap({
     );
     const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
-    const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
-
     useEffect(() => {
-        if (!apiKey) {
-            setStatus("error");
-            setErrorMsg("Google Maps API-Key fehlt");
-            return;
-        }
         if (!polygon?.length || !containerRef.current) return;
 
         let cancelled = false;
@@ -117,7 +110,7 @@ export default function Region3DMap({
         return () => {
             cancelled = true;
         };
-    }, [apiKey, polygon]);
+    }, [polygon]);
 
     return (
         <div className={className}>

--- a/src/components/map/street-level/AppleLookAround.tsx
+++ b/src/components/map/street-level/AppleLookAround.tsx
@@ -69,6 +69,10 @@ export default function AppleLookAround({
             if (!activeRef.current || suppressReportingRef.current || !lookAround) {
                 return;
             }
+            // Skip polling work while the tab is backgrounded.
+            if (typeof document !== "undefined" && document.hidden) {
+                return;
+            }
 
             const coordinate = lookAround.scene?.coordinate ?? lookAround.centerCoordinate;
             if (!coordinate) {
@@ -125,7 +129,7 @@ export default function AppleLookAround({
                         suppressReportingRef.current = false;
                         setStatus("ready");
                         reportCurrentLocation();
-                        locationTimer = window.setInterval(reportCurrentLocation, 200);
+                        locationTimer = window.setInterval(reportCurrentLocation, 500);
                     }
                 }, { once: true });
 

--- a/src/components/profile/RegionsTable.tsx
+++ b/src/components/profile/RegionsTable.tsx
@@ -4,7 +4,6 @@ import { useState, useMemo } from "react";
 import {
     Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { stateCodeToName } from "@/lib/federalStates";
 import {
@@ -33,18 +32,6 @@ type SortKey = "city" | "state" | "area" | "buildings" | "createdAt" | "type";
 type SortDir = "asc" | "desc";
 
 const PAGE_SIZE = 10;
-
-const TYPE_LABELS: Record<Region["type"], string> = {
-    default: "Standard",
-    plot: "Plot",
-    event: "Event",
-};
-
-const TYPE_STYLES: Record<Region["type"], string> = {
-    default: "border-blue-500/30 bg-blue-500/10 text-blue-400",
-    plot: "border-green-500/30 bg-green-500/10 text-green-400",
-    event: "border-purple-500/30 bg-purple-500/10 text-purple-400",
-};
 
 function formatArea(area: string | number): string {
     const n = typeof area === "string" ? parseFloat(area) : area;

--- a/src/components/search/SearchDialog.tsx
+++ b/src/components/search/SearchDialog.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/command";
 import useSearchStore from "@/stores/SearchStore";
 import useRegionPane from "@/stores/RegionPaneStore";
-import { useAllRegions } from "@/dataHooks/regions/useAllRegions";
+import { useRegionsForSearch } from "@/dataHooks/regions/useAllRegions";
 import { usePhotonSearch, formatPhotonLabel, type PhotonFeature } from "@/dataHooks/search/usePhotonSearch";
 import { stateCodeToName } from "@/lib/federalStates";
 
@@ -27,7 +27,6 @@ type Region = {
     description: string | null;
     type: string;
     finished: boolean;
-    polygon: [number, number][];
 };
 
 function useDebounced<T>(value: T, delay = 250): T {
@@ -64,7 +63,7 @@ export default function SearchDialog() {
     const [query, setQuery] = useState("");
     const debouncedQuery = useDebounced(query, 250);
 
-    const { data: regions } = useAllRegions();
+    const { data: regions } = useRegionsForSearch();
     const { data: photonResults, isFetching: isPhotonLoading } = usePhotonSearch(debouncedQuery);
 
     // Reset query when dialog closes

--- a/src/components/welcome/WelcomeScreen.tsx
+++ b/src/components/welcome/WelcomeScreen.tsx
@@ -4,12 +4,10 @@ import {
     Dialog,
     DialogClose,
     DialogContent,
-    DialogDescription,
     DialogFooter,
     DialogHeader,
     DialogOverlay,
     DialogTitle,
-    DialogTrigger,
 } from "@/components/ui/dialog"
 
 import Image from "next/image";

--- a/src/dataHooks/minecraft/useMcUser.tsx
+++ b/src/dataHooks/minecraft/useMcUser.tsx
@@ -1,16 +1,10 @@
-import {useQuery} from "@tanstack/react-query";
-import {getAllRegions, getAllRegionsAsGeoJSON, getRegion} from "@/actions/region/GetRegions";
+import { useQuery } from "@tanstack/react-query";
 import getUser from "@/actions/minecraft/user";
 
 const useMcUser = (mcUuid: string) => useQuery({
     queryKey: ['mcUser', mcUuid],
-    queryFn: () => {
-        if (mcUuid) {
-            return getUser(mcUuid)
-        } else {
-            return Promise.resolve(null)
-        }
-    }
-})
+    queryFn: () => getUser(mcUuid),
+    enabled: !!mcUuid,
+});
 
-export {useMcUser};
+export { useMcUser };

--- a/src/dataHooks/regions/useAllRegions.tsx
+++ b/src/dataHooks/regions/useAllRegions.tsx
@@ -1,9 +1,10 @@
-import {useQuery} from "@tanstack/react-query";
-import {getAllRegions, getAllRegionsAsGeoJSON} from "@/actions/region/GetRegions";
+import { useQuery } from "@tanstack/react-query";
+import { getAllRegionsAsGeoJSON, getRegionsForSearch } from "@/actions/region/GetRegions";
 
-const useAllRegions = () => useQuery({
-    queryKey: ['regions'],
-    queryFn: () => getAllRegions()
+// Minimal, public-safe region list for the search box (no creator/builder UUIDs).
+const useRegionsForSearch = () => useQuery({
+    queryKey: ['regions_search'],
+    queryFn: () => getRegionsForSearch()
 })
 
 const useAllRegionsAsGeoJSON = () => useQuery({
@@ -11,4 +12,4 @@ const useAllRegionsAsGeoJSON = () => useQuery({
     queryFn: () => getAllRegionsAsGeoJSON()
 })
 
-export {useAllRegions, useAllRegionsAsGeoJSON};
+export { useRegionsForSearch, useAllRegionsAsGeoJSON };

--- a/src/dataHooks/regions/useRegion.tsx
+++ b/src/dataHooks/regions/useRegion.tsx
@@ -1,16 +1,10 @@
-import {useQuery} from "@tanstack/react-query";
-import {getAllRegions, getAllRegionsAsGeoJSON, getRegion} from "@/actions/region/GetRegions";
+import { useQuery } from "@tanstack/react-query";
+import { getRegion } from "@/actions/region/GetRegions";
 
-const useRegion = (regionId: string) => useQuery({
+const useRegion = (regionId: string | null | undefined) => useQuery({
     queryKey: ['region', regionId],
-    queryFn: () => {
-        if (regionId) {
-            return getRegion(regionId)
-        } else {
-            return Promise.resolve(null)
-        }
-    }
-})
+    queryFn: () => getRegion(regionId!),
+    enabled: !!regionId,
+});
 
-
-export {useRegion};
+export { useRegion };

--- a/src/db/drizzle.ts
+++ b/src/db/drizzle.ts
@@ -20,19 +20,24 @@ function getSslConfig() {
     };
 }
 
-if (process.env.NODE_ENV === 'production') {
-    const pool = new Pool({
+// Bound the pool and per-statement time so a stuck upstream can't pin
+// connections (and long-lived SSE handlers) open indefinitely.
+function createPool() {
+    return new Pool({
         connectionString: process.env.DATABASE_URL,
         ssl: getSslConfig(),
+        max: 10,
+        connectionTimeoutMillis: 5_000,
+        statement_timeout: 15_000,
+        query_timeout: 15_000,
     });
-    db = drizzle(pool);
+}
+
+if (process.env.NODE_ENV === 'production') {
+    db = drizzle(createPool());
 } else {
     if (!globalThis.db) {
-        const pool = new Pool({
-            connectionString: process.env.DATABASE_URL,
-            ssl: getSslConfig(),
-        });
-        globalThis.db = drizzle(pool);
+        globalThis.db = drizzle(createPool());
     }
     db = globalThis.db!;
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm"
-import { boolean, integer, json, numeric, pgEnum, pgTable, text, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
+import { boolean, index, integer, json, numeric, pgEnum, pgTable, text, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
 
 export const regionType = pgEnum('region_type', ['default', 'plot', 'event']);
 
@@ -28,7 +28,9 @@ export const region = pgTable("regions", {
 	address: text().default('').notNull(),
 	finished: boolean().default(false).notNull(),
 	builders: json("builders").$type<string[]>(),
-});
+}, (table) => [
+	index("regions_creator_uuid_idx").on(table.creatorUUID),
+]);
 
 export const regionImage = pgTable("region_images", {
 	id: uuid().primaryKey().defaultRandom(),
@@ -39,7 +41,9 @@ export const regionImage = pgTable("region_images", {
 	sizeBytes: integer("size_bytes").notNull(),
 	originalName: varchar("original_name", { length: 256 }),
 	createdAt: timestamp("created_at").defaultNow().notNull(),
-});
+}, (table) => [
+	index("region_images_region_id_idx").on(table.regionId),
+]);
 
 /**
  * A single Minecraft Paper server in the network. The plugin running on it
@@ -92,7 +96,10 @@ export const playerPosition = pgTable("player_positions", {
 	lat: numeric("lat"),
 	lng: numeric("lng"),
 	lastSeenAt: timestamp("last_seen_at").defaultNow().notNull(),
-});
+}, (table) => [
+	index("player_positions_server_last_seen_idx").on(table.serverKey, table.lastSeenAt),
+	index("player_positions_last_seen_idx").on(table.lastSeenAt),
+]);
 
 export const teleportStatus = pgEnum('teleport_status', ['pending', 'delivered', 'failed', 'expired']);
 
@@ -121,5 +128,7 @@ export const teleportRequest = pgTable("teleport_requests", {
 	createdAt: timestamp("created_at").defaultNow().notNull(),
 	deliveredAt: timestamp("delivered_at"),
 	error: text("error"),
-});
+}, (table) => [
+	index("teleport_requests_status_idx").on(table.status),
+]);
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,8 +1,6 @@
-import { log } from 'console';
-import NextAuth, { AuthOptions, Session, getServerSession } from 'next-auth';
+import { AuthOptions, Session, getServerSession } from 'next-auth';
 import { JWT } from 'next-auth/jwt';
 import KeycloakProvider from 'next-auth/providers/keycloak';
-import { signOut } from 'next-auth/react';
 import process from 'process';
 
 /**
@@ -49,8 +47,9 @@ const refreshAccessToken = async (token: JWT) => {
         const refreshedTokens = await response.json();
 
         if (!response.ok) {
-            console.error('[Auth] Failed to refresh token:', refreshedTokens);
-            throw refreshedTokens;
+            // Never log the raw token response — it can contain access/refresh tokens.
+            console.error('[Auth] Failed to refresh token, status:', response.status);
+            throw new Error(`Token refresh failed (${response.status})`);
         }
 
         const refreshedAccessExpiresIn = refreshedTokens.expires_in ?? 0;
@@ -165,8 +164,12 @@ export const authOptions: AuthOptions = {
                     return session;
                 }
 
-                // @ts-expect-error shut up typescript
-                session.user = token.user;
+                // token.user carries the full Keycloak profile at runtime; its
+                // static type (next-auth's User) under-describes those claims,
+                // so we assert the richer session-user shape here at the boundary.
+                if (token.user) {
+                    session.user = token.user as unknown as Session["user"];
+                }
                 session.error = token.error;
                 session.accessToken = token.accessToken;
             }

--- a/src/lib/buildings.ts
+++ b/src/lib/buildings.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { getErrorMessage } from "@/lib/errors";
 
 /**
  * Zählt die Anzahl Gebäude innerhalb eines Polygons via Overpass.
@@ -16,8 +17,9 @@ export async function fetchBuildingCount(polygon: [number, number][]): Promise<n
 );
 out count;`;
 
-    console.log("[buildings] fetching count with query:", query);
-
+    if (process.env.DEBUG_OVERPASS) {
+        console.log("[buildings] fetching count with query:", query);
+    }
 
     try {
         const res = await axios.post(
@@ -32,8 +34,8 @@ out count;`;
             }
         );
         return parseInt(res.data?.elements?.[0]?.tags?.total) || 0;
-    } catch (err: any) {
-        console.error("[buildings] count failed:", err?.message ?? err);
+    } catch (err: unknown) {
+        console.error("[buildings] count failed:", getErrorMessage(err));
         return 0;
     }
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,10 @@
+/** Narrow an unknown thrown value to a human-readable message. */
+export function getErrorMessage(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    if (typeof error === "string") return error;
+    try {
+        return JSON.stringify(error);
+    } catch {
+        return String(error);
+    }
+}

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared geometry helpers used by region/teleport actions and routes.
+ * Polygons are stored in the DB as `[[lat, lng], ...]`.
+ */
+
+/** Ensures a polygon ring is closed (first point === last point). */
+export function closePolygon(coords: [number, number][]): [number, number][] {
+    if (coords.length < 2) return coords;
+    const first = coords[0];
+    const last = coords[coords.length - 1];
+    if (first[0] === last[0] && first[1] === last[1]) return coords;
+    return [...coords, first];
+}
+
+/** Simple centroid (average of vertices) of a `[lat, lng]` polygon. */
+export function polygonCenterLatLng(polygon: [number, number][]): [number, number] {
+    let lat = 0;
+    let lng = 0;
+    for (const [a, b] of polygon) {
+        lat += a;
+        lng += b;
+    }
+    return [lat / polygon.length, lng / polygon.length];
+}

--- a/src/lib/googleMapsBrowser.ts
+++ b/src/lib/googleMapsBrowser.ts
@@ -1,3 +1,5 @@
+import { getPublicRuntimeConfig } from "@/lib/publicRuntimeConfig";
+
 const GOOGLE_MAPS_SCRIPT_ID = "google-maps-javascript-sdk";
 const GOOGLE_MAPS_CALLBACK = "__bteGoogleMapsLoaded";
 
@@ -22,39 +24,68 @@ export function loadGoogleMaps(): Promise<typeof google.maps> {
         return googleMapsPromise;
     }
 
-    const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
-    if (!apiKey) {
-        return Promise.reject(new Error("NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ist nicht konfiguriert."));
-    }
+    googleMapsPromise = getPublicRuntimeConfig()
+        .then(
+            ({ googleMapsApiKey }) =>
+                new Promise<typeof google.maps>((resolve, reject) => {
+                    if (!googleMapsApiKey) {
+                        reject(
+                            new Error(
+                                "Google Maps Browser API-Key ist nicht konfiguriert.",
+                            ),
+                        );
+                        return;
+                    }
 
-    googleMapsPromise = new Promise((resolve, reject) => {
-        const existingScript = document.getElementById(GOOGLE_MAPS_SCRIPT_ID) as HTMLScriptElement | null;
+                    const existingScript = document.getElementById(
+                        GOOGLE_MAPS_SCRIPT_ID,
+                    ) as HTMLScriptElement | null;
 
-        window[GOOGLE_MAPS_CALLBACK] = () => {
-            delete window[GOOGLE_MAPS_CALLBACK];
-            if (window.google?.maps) {
-                resolve(window.google.maps);
-            } else {
-                reject(new Error("Google Maps wurde nicht korrekt initialisiert."));
-            }
-        };
+                    window[GOOGLE_MAPS_CALLBACK] = () => {
+                        delete window[GOOGLE_MAPS_CALLBACK];
+                        if (window.google?.maps) {
+                            resolve(window.google.maps);
+                        } else {
+                            reject(
+                                new Error(
+                                    "Google Maps wurde nicht korrekt initialisiert.",
+                                ),
+                            );
+                        }
+                    };
 
-        if (existingScript) {
-            existingScript.addEventListener("error", () => reject(new Error("Google Maps konnte nicht geladen werden.")), { once: true });
-            return;
-        }
+                    if (existingScript) {
+                        existingScript.addEventListener(
+                            "error",
+                            () =>
+                                reject(
+                                    new Error(
+                                        "Google Maps konnte nicht geladen werden.",
+                                    ),
+                                ),
+                            { once: true },
+                        );
+                        return;
+                    }
 
-        const script = document.createElement("script");
-        script.id = GOOGLE_MAPS_SCRIPT_ID;
-        script.async = true;
-        script.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(apiKey)}&v=beta&loading=async&callback=${GOOGLE_MAPS_CALLBACK}`;
-        script.onerror = () => {
+                    const script = document.createElement("script");
+                    script.id = GOOGLE_MAPS_SCRIPT_ID;
+                    script.async = true;
+                    script.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(googleMapsApiKey)}&v=beta&loading=async&callback=${GOOGLE_MAPS_CALLBACK}`;
+                    script.onerror = () => {
+                        googleMapsPromise = null;
+                        delete window[GOOGLE_MAPS_CALLBACK];
+                        reject(
+                            new Error("Google Maps konnte nicht geladen werden."),
+                        );
+                    };
+                    document.head.appendChild(script);
+                }),
+        )
+        .catch((error) => {
             googleMapsPromise = null;
-            delete window[GOOGLE_MAPS_CALLBACK];
-            reject(new Error("Google Maps konnte nicht geladen werden."));
-        };
-        document.head.appendChild(script);
-    });
+            throw error;
+        });
 
     return googleMapsPromise;
 }

--- a/src/lib/guards.ts
+++ b/src/lib/guards.ts
@@ -1,0 +1,91 @@
+import { eq } from "drizzle-orm";
+import db from "@/db/drizzle";
+import { region } from "@/db/schema";
+import { getSession } from "@/lib/auth";
+import { hasPermission, type Permission } from "@/lib/permissions";
+
+/**
+ * Centralised authentication / authorization guards for server actions.
+ *
+ * Every mutating action previously repeated the same session lookup,
+ * `(session.user as any).realm_access` cast and ownership check. Those casts
+ * were unnecessary (the fields are declared in `next-auth.d.ts`) and the
+ * duplicated logic drifted between call sites. Keeping the rules here means
+ * they live in exactly one place.
+ */
+
+const UUID_RE =
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/** Throws unless `value` is a syntactically valid UUID. Returns it otherwise. */
+export function assertUuid(value: string | null | undefined, label = "ID"): string {
+    if (!value || !UUID_RE.test(value)) {
+        throw new Error(`Ungültige ${label}.`);
+    }
+    return value;
+}
+
+export interface SessionContext {
+    roles: string[];
+    userUuid?: string;
+    username?: string;
+}
+
+/** Requires an authenticated session and returns a normalised context. */
+export async function requireSession(): Promise<SessionContext> {
+    const session = await getSession();
+    if (!session?.user) throw new Error("Nicht angemeldet");
+    return {
+        roles: session.user.realm_access?.roles ?? [],
+        userUuid: session.user.minecraft_uuid,
+        username: session.user.preferred_username,
+    };
+}
+
+/** Requires an authenticated session that holds `permission`. */
+export async function requirePermission(permission: Permission): Promise<SessionContext> {
+    const ctx = await requireSession();
+    if (!hasPermission(ctx.roles, permission)) {
+        throw new Error("Keine Berechtigung");
+    }
+    return ctx;
+}
+
+/** Requires a logged-in user with a linked, valid Minecraft UUID. */
+export async function requireLinkedUuid(): Promise<string> {
+    const ctx = await requireSession();
+    return assertUuid(ctx.userUuid, "Minecraft-UUID");
+}
+
+export interface RegionAccess {
+    userUuid?: string;
+    isAdmin: boolean;
+    isCreator: boolean;
+}
+
+/**
+ * Authorizes access to a single region: allowed for the region's creator and
+ * for any user holding `permission` (defaults to REGIONS_EDIT semantics passed
+ * by the caller). Validates the region id and confirms the region exists.
+ */
+export async function requireRegionAccess(
+    regionId: string,
+    permission: Permission,
+): Promise<RegionAccess> {
+    assertUuid(regionId, "Region-ID");
+    const ctx = await requireSession();
+    const isAdmin = hasPermission(ctx.roles, permission);
+
+    const existing = await db
+        .select({ creatorUUID: region.creatorUUID })
+        .from(region)
+        .where(eq(region.id, regionId))
+        .limit(1)
+        .then((r) => r[0]);
+    if (!existing) throw new Error("Region nicht gefunden");
+
+    const isCreator = !!ctx.userUuid && existing.creatorUUID === ctx.userUuid;
+    if (!isCreator && !isAdmin) throw new Error("Keine Berechtigung");
+
+    return { userUuid: ctx.userUuid, isAdmin, isCreator };
+}

--- a/src/lib/landuse.ts
+++ b/src/lib/landuse.ts
@@ -73,7 +73,28 @@ function stitchOuterRing(segments: Coord[][]): Coord[] | null {
     return result.length >= 4 ? result : null;
 }
 
-function tryIntersectArea(regionPoly: Feature<Polygon>, coords: Coord[]): number {
+type BBox = [number, number, number, number]; // [minX, minY, maxX, maxY] in [lng, lat]
+
+function bboxOfCoords(coords: Coord[]): BBox {
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const [x, y] of coords) {
+        if (x < minX) minX = x;
+        if (x > maxX) maxX = x;
+        if (y < minY) minY = y;
+        if (y > maxY) maxY = y;
+    }
+    return [minX, minY, maxX, maxY];
+}
+
+function bboxesOverlap(a: BBox, b: BBox): boolean {
+    return !(a[0] > b[2] || a[2] < b[0] || a[1] > b[3] || a[3] < b[1]);
+}
+
+function tryIntersectArea(regionPoly: Feature<Polygon>, regionBbox: BBox, coords: Coord[]): number {
+    // Cheap axis-aligned bounding-box rejection before the expensive polygon
+    // clip: if the boxes don't overlap the polygons cannot intersect (area 0),
+    // and Overpass's ~1km-padded bbox returns many such non-overlapping elements.
+    if (!bboxesOverlap(bboxOfCoords(coords), regionBbox)) return 0;
     try {
         const poly = turf.polygon([coords]);
         const intersection = turf.intersect(turf.featureCollection([regionPoly, poly]));
@@ -108,7 +129,9 @@ export async function fetchLandUseStats(polygon: [number, number][]): Promise<La
 );
 out geom;`;
 
-    console.log("[landuse] fetching stats with query:", query);
+    if (process.env.DEBUG_OVERPASS) {
+        console.log("[landuse] fetching stats with query:", query);
+    }
 
     const { data } = await axios.post(
         process.env.OVERPASS_API_URL!,
@@ -116,7 +139,9 @@ out geom;`;
         { headers: { "Content-Type": "application/x-www-form-urlencoded", "apikey": process.env.OVERPASS_API_KEY }, timeout: 35_000 }
     );
 
-    const regionPoly = turf.polygon([polygon.map(coord => [coord[1], coord[0]])]);
+    const regionRing: Coord[] = polygon.map(coord => [coord[1], coord[0]] as Coord);
+    const regionPoly = turf.polygon([regionRing]);
+    const regionBbox = bboxOfCoords(regionRing);
     const stats: LandUseStats = { forest: 0, water: 0, farmland: 0, residential: 0, industrial: 0, park: 0 };
 
     for (const element of data?.elements ?? []) {
@@ -135,7 +160,7 @@ out geom;`;
             }
             if (coords.length < 4) continue;
 
-            stats[category] += tryIntersectArea(regionPoly, coords);
+            stats[category] += tryIntersectArea(regionPoly, regionBbox, coords);
 
         } else if (element.type === "relation") {
             if (!Array.isArray(element.members)) continue;
@@ -149,7 +174,7 @@ out geom;`;
             const ring = stitchOuterRing(outerSegments);
             if (!ring) continue;
 
-            stats[category] += tryIntersectArea(regionPoly, ring);
+            stats[category] += tryIntersectArea(regionPoly, regionBbox, ring);
         }
     }
 

--- a/src/lib/mcAuth.ts
+++ b/src/lib/mcAuth.ts
@@ -85,6 +85,15 @@ export function bearerFromRequest(req: Request): string | null {
 }
 
 export async function requireMcAuth(req: Request): Promise<McAuthContext> {
+    // Optional mTLS gate (no-op unless MC_REQUIRE_MTLS_HEADER=1 is configured).
+    const mtls = checkMtlsHeader(req);
+    if (!mtls.ok) {
+        throw new Response(JSON.stringify({ error: "Forbidden", reason: mtls.reason }), {
+            status: 403,
+            headers: { "content-type": "application/json" },
+        });
+    }
+
     const ctx = await verifyMcToken(bearerFromRequest(req));
     if (!ctx) {
         throw new Response(JSON.stringify({ error: "Unauthorized" }), {

--- a/src/lib/publicRuntimeConfig.ts
+++ b/src/lib/publicRuntimeConfig.ts
@@ -1,0 +1,33 @@
+export interface PublicRuntimeConfig {
+    mapboxAccessToken: string;
+    googleMapsApiKey: string;
+}
+
+let configPromise: Promise<PublicRuntimeConfig> | null = null;
+
+export function getPublicRuntimeConfig(): Promise<PublicRuntimeConfig> {
+    if (typeof window === "undefined") {
+        return Promise.reject(
+            new Error("Die öffentliche Runtime-Konfiguration ist nur im Browser verfügbar."),
+        );
+    }
+
+    if (!configPromise) {
+        configPromise = fetch("/api/config", { cache: "no-store" })
+            .then(async (response) => {
+                if (!response.ok) {
+                    throw new Error(
+                        `Runtime-Konfiguration konnte nicht geladen werden (${response.status}).`,
+                    );
+                }
+
+                return response.json() as Promise<PublicRuntimeConfig>;
+            })
+            .catch((error) => {
+                configPromise = null;
+                throw error;
+            });
+    }
+
+    return configPromise;
+}

--- a/src/lib/regionGeo.ts
+++ b/src/lib/regionGeo.ts
@@ -1,0 +1,20 @@
+import type { FeatureCollection, Polygon } from "geojson";
+
+export type RegionGeoJSON = FeatureCollection<Polygon, { id: string; finished: boolean }>;
+
+/** Region rows are stored as `[[lat, lng], ...]`; GeoJSON wants `[lng, lat]`. */
+export function regionsToCreatorGeoJSON(
+    regions: { id: string; finished: boolean; polygon: [number, number][] }[],
+): RegionGeoJSON {
+    return {
+        type: "FeatureCollection",
+        features: regions.map((r) => ({
+            type: "Feature",
+            properties: { id: r.id, finished: r.finished },
+            geometry: {
+                type: "Polygon",
+                coordinates: [r.polygon.map((e) => [e[1], e[0]]) as [number, number][]],
+            },
+        })),
+    };
+}

--- a/src/stores/RegionPaneStore.ts
+++ b/src/stores/RegionPaneStore.ts
@@ -5,10 +5,11 @@ export type BoundsTuple = [number, number, number, number];
 
 interface RegionPaneStore {
     open: boolean,
-    region: any,
-    openRegion: (region: string) => void,
+    /** The id of the region whose pane is open (null when closed). */
+    region: string | null,
+    openRegion: (regionId: string) => void,
     setOpen: (open: boolean) => void,
-    setRegion: (region: any) => void,
+    setRegion: (regionId: string) => void,
     restoreBox: BoundsTuple | null
     setRestoreBox: (restoreBox: BoundsTuple) => void
 }
@@ -16,11 +17,11 @@ interface RegionPaneStore {
 const useRegionPane = create<RegionPaneStore>()(devtools((set) => ({
     open: false,
     region: null,
-    openRegion: (region: string) => {
-        set({ region, open: true })
+    openRegion: (regionId: string) => {
+        set({ region: regionId, open: true })
     },
     setOpen: (open: boolean) => set({ open }),
-    setRegion: (region: any) => set({ region }),
+    setRegion: (regionId: string) => set({ region: regionId }),
     restoreBox: null,
     setRestoreBox: (restoreBox: BoundsTuple) => set({ restoreBox })
 })))


### PR DESCRIPTION
Verified with `tsc --noEmit` (clean), `next lint` (0 errors), and `next build` (passes).

Security & correctness
- Sanitize a real legacy DB credential that had been pasted into the tracked .env.migration.example; restore the placeholder (rotate the leaked password).
- Centralize auth/permission/ownership in src/lib/guards.ts; drop the unnecessary `(session.user as any)` casts; validate UUIDs and coordinate/ polygon bounds at action/route boundaries.
- Stop leaking upstream/zod error details to clients; scrub Keycloak token logging in auth.ts.
- Bound the pg pool (statement/query/connection timeouts) so a hung upstream can't pin SSE connections.
- Make region delete and creator transfer atomic via transactions.
- Require auth (+ MAP_STREET_LEVEL_VIEW) on the Apple Maps token route.
- Wire the documented mTLS header check into requireMcAuth.

Best practices
- Remove next.config `eslint.ignoreDuringBuilds` and fix the lint errors it hid; set no-explicit-any to a (visible) warning; add security headers.
- Remove dead code/imports; gate Overpass debug logs behind DEBUG_OVERPASS.
- Per-instance React Query client; typed zustand store; query `enabled` flags; fix an in-place polygon mutation in the OG image route.

Performance (region metadata)
- Cache playerdb getUser via the Next Data Cache (kills the per-builder N+1).
- Add a bbox pre-filter before turf.intersect in landuse stats.
- Replace the sequential bulk metadata refresh with a bounded worker pool.
- Defer building-count to a background write on region create.
- Consolidate the profile stat queries and stop fetching the creator's rows twice; drop polygon/UUID columns from the stats, search and geojson payloads.
- Add DB indexes (migration 0003_perf_indexes) for creator/region-image/ teleport-status/player-position lookups.

Also includes pending street-level (Street View / Look Around) feature work that was already present in the working tree.


Claude-Session: https://claude.ai/code/session_01DesXo9CpJVpWW6bnganwjC